### PR TITLE
LPOracle: Simulate Order & _normalizePrices

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -6,6 +6,7 @@ import { BaseScript } from "./Base.s.sol";
 /// @dev See the Solidity Scripting tutorial: https://book.getfoundry.sh/tutorials/solidity-scripting
 contract Deploy is BaseScript {
     function run() public broadcast {
+        // TODO: https://github.com/lumoswiz/cow-amm-lp-oracle/issues/6
         // oracle = new LPOracleFactory();
     }
 }

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -1,13 +1,11 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.25 <0.9.0;
 
-import { LPOracle } from "../src/LPOracle.sol";
-
 import { BaseScript } from "./Base.s.sol";
 
 /// @dev See the Solidity Scripting tutorial: https://book.getfoundry.sh/tutorials/solidity-scripting
 contract Deploy is BaseScript {
-    function run() public broadcast returns (LPOracle oracle) {
-        oracle = new LPOracle();
+    function run() public broadcast {
+        // oracle = new LPOracleFactory();
     }
 }

--- a/src/LPOracle.sol
+++ b/src/LPOracle.sol
@@ -1,7 +1,61 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
+import { ICOWAMMPoolHelper } from "@cow-amm/interfaces/ICOWAMMPoolHelper.sol";
+import { GPv2Order } from "cowprotocol/contracts/libraries/GPv2Order.sol";
+import { IERC20 } from "cowprotocol/contracts/interfaces/IERC20.sol";
+
 contract LPOracle {
+    /// @notice BCoWPool address.
+    address public immutable POOL;
+    /// @notice BCoWHelper contract.
+    ICOWAMMPoolHelper public immutable HELPER;
+
+    /// @notice Pool tokens.
+    /// @dev Tokens at indicies 0 and 1 in `getFinalTokens` function. Use same order for input prices vector to `order`
+    /// function.
+    IERC20 public immutable TOKEN0;
+    IERC20 public immutable TOKEN1;
+
+    /// @notice Pool token 0 decimals
+    uint256 public immutable TOKEN0_DECIMALS;
+
+    /// @notice Pool token 1 decimals
+    uint256 public immutable TOKEN1_DECIMALS;
+
+    /// @dev Must check Chainlink price feeds match pool token ordering.
+    /// @param _pool BCoWPool address.
+    /// @param _helper BCoWHelper address.
+    constructor(address _pool, address _helper) {
+        /* Set pool and helper contracts */
+        POOL = _pool;
+        HELPER = ICOWAMMPoolHelper(_helper);
+
+        /* Gets pool tokens with correct ordering and pool validation checks */
+        address[] memory tokens = HELPER.tokens(POOL);
+        TOKEN0 = IERC20(tokens[0]);
+        TOKEN1 = IERC20(tokens[1]);
+
+        TOKEN0_DECIMALS = TOKEN0.decimals();
+        TOKEN1_DECIMALS = TOKEN1.decimals();
+    }
+
+    /// @notice Retrieves the order to satisfy the pool's invariants given the token prices.
+    /// @dev Zero fee constant function AMM.
+    /// @dev Decimals for price0 and price1 should be identical.
+    /// @param price0 USD price of pool token 0.
+    /// @param price1 USD price of pool token 1.
+    /// @return order Order required to satisfy pool's invariants given the input pricing vector.
+    function _simulateOrder(uint256 price0, uint256 price1) internal view returns (GPv2Order.Data memory order) {
+        /* Setup prices vector */
+        uint256[] memory prices = new uint256[](2);
+        prices[0] = 1e18;
+        prices[1] = (price1 * (10 ** TOKEN0_DECIMALS) * 1e18) / (price0 * (10 ** TOKEN1_DECIMALS));
+
+        /* Simulate the order */
+        (order,,,) = HELPER.order(POOL, prices);
+    }
+
     /// @notice Adjusts input values according to decimals.
     /// @dev Used to adjust pool reserve balances and price feed answers.
     /// @param value0 Value associated with pool token 0.

--- a/src/LPOracle.sol
+++ b/src/LPOracle.sol
@@ -47,13 +47,21 @@ contract LPOracle {
     /// @param price1 USD price of pool token 1.
     /// @return order Order required to satisfy pool's invariants given the input pricing vector.
     function _simulateOrder(uint256 price0, uint256 price1) internal view returns (GPv2Order.Data memory order) {
-        /* Setup prices vector */
-        uint256[] memory prices = new uint256[](2);
-        prices[0] = 1e18;
-        prices[1] = (price1 * (10 ** TOKEN0_DECIMALS) * 1e18) / (price0 * (10 ** TOKEN1_DECIMALS));
-
+        uint256[] memory prices = _normalizePrices(price0, price1);
         /* Simulate the order */
         (order,,,) = HELPER.order(POOL, prices);
+    }
+
+    /// @notice Normalizes input prices to the format expected by the pool helper
+    /// @dev First price is normalized to 1e18, second price is adjusted relative to first price
+    /// @dev Takes into account token decimals when calculating relative price
+    /// @param price0 price of pool token 0
+    /// @param price1 price of pool token 1
+    /// @return prices Array of normalized prices where prices[0] = 1e18 and prices[1] is the relative price
+    function _normalizePrices(uint256 price0, uint256 price1) internal view returns (uint256[] memory prices) {
+        prices = new uint256[](2);
+        prices[0] = 1e18;
+        prices[1] = (price1 * (10 ** TOKEN0_DECIMALS) * 1e18) / (price0 * (10 ** TOKEN1_DECIMALS));
     }
 
     /// @notice Adjusts input values according to decimals.

--- a/test/unit/LPOracle.t.sol
+++ b/test/unit/LPOracle.t.sol
@@ -1,11 +1,21 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.8.25;
 
+import { console } from "forge-std/console.sol";
 import { Test } from "forge-std/Test.sol";
 import { LPOracle } from "src/LPOracle.sol";
+import { GPv2Order } from "cowprotocol/contracts/libraries/GPv2Order.sol";
 
 contract ExposedLPOracle is LPOracle {
     constructor(address _pool, address _helper) LPOracle(_pool, _helper) { }
+
+    function exposed_simulateOrder(uint256 price0, uint256 price1) external view returns (GPv2Order.Data memory) {
+        return _simulateOrder(price0, price1);
+    }
+
+    function exposed_normalizePrices(uint256 price0, uint256 price1) external view returns (uint256[] memory) {
+        return _normalizePrices(price0, price1);
+    }
 
     function exposed_adjustDecimals(
         uint256 value0,
@@ -21,27 +31,43 @@ contract ExposedLPOracle is LPOracle {
     }
 }
 
-contract TestLPOracle is Test {
+abstract contract BaseTest is Test {
+    address internal constant MOCK_HELPER = address(1);
+    address internal constant MOCK_POOL = address(2);
+    address internal constant TOKEN0 = address(0x1111111111111111111111111111111111111111);
+    address internal constant TOKEN1 = address(0x2222222222222222222222222222222222222222);
+
     ExposedLPOracle internal oracle;
 
-    function setUp() public {
-        // Mock the helper.tokens() call
-        address mockHelper = address(1);
-        address mockPool = address(2);
-
-        // Create return data for tokens() call
-        address[] memory tokens = new address[](2);
-        tokens[0] = address(0x1111111111111111111111111111111111111111);
-        tokens[1] = address(0x2222222222222222222222222222222222222222);
-        // Mock the helper.tokens() call
-        vm.mockCall(mockHelper, abi.encodeWithSignature("tokens(address)", mockPool), abi.encode(tokens));
-
-        // Mock decimals() calls for both tokens
-        vm.mockCall(tokens[0], abi.encodeWithSignature("decimals()"), abi.encode(uint8(18)));
-        vm.mockCall(tokens[1], abi.encodeWithSignature("decimals()"), abi.encode(uint8(18)));
-        oracle = new ExposedLPOracle(mockPool, mockHelper);
+    function setUp() public virtual {
+        // Setup default token configuration with 18 decimals
+        setTokenDecimals(18, 18);
+        // Initialize oracle with default configuration
+        oracle = new ExposedLPOracle(MOCK_POOL, MOCK_HELPER);
     }
 
+    function setTokenDecimals(uint8 decimals0, uint8 decimals1) internal {
+        // Setup token addresses
+        address[] memory tokens = new address[](2);
+        tokens[0] = TOKEN0;
+        tokens[1] = TOKEN1;
+
+        // Mock helper.tokens() call
+        vm.mockCall(MOCK_HELPER, abi.encodeWithSignature("tokens(address)", MOCK_POOL), abi.encode(tokens));
+
+        // Mock decimals() calls for both tokens
+        vm.mockCall(TOKEN0, abi.encodeWithSignature("decimals()"), abi.encode(decimals0));
+        vm.mockCall(TOKEN1, abi.encodeWithSignature("decimals()"), abi.encode(decimals1));
+    }
+
+    // Helper to reinitialize oracle after changing decimals
+    function reinitOracle(uint8 decimals0, uint8 decimals1) internal {
+        setTokenDecimals(decimals0, decimals1);
+        oracle = new ExposedLPOracle(MOCK_POOL, MOCK_HELPER);
+    }
+}
+
+contract TestLPOracle is BaseTest {
     function test_adjustDecimals_SameDecimals() public view {
         (uint256 adjusted0, uint256 adjusted1) = oracle.exposed_adjustDecimals(
             100, // value0
@@ -131,5 +157,62 @@ contract TestLPOracle is Test {
             assertEq(adjusted0, value0);
             assertEq(adjusted1, value1);
         }
+    }
+
+    function test_normalizePrices() public view {
+        // Using default oracle configuration (18 decimals for both tokens)
+        // Test case where both tokens have and same price
+        uint256[] memory prices = oracle.exposed_normalizePrices(1000e18, 1000e18);
+        assertEq(prices[0], 1e18, "First price should always be 1e18");
+        assertEq(prices[1], 1e18, "Equal prices should result in 1e18");
+
+        // Test case where token1 is worth twice as much as token0
+        prices = oracle.exposed_normalizePrices(1000e18, 2000e18);
+        assertEq(prices[0], 1e18, "First price should always be 1e18");
+        assertEq(prices[1], 2e18, "Token1 should be worth 2x token0");
+
+        // Test case where token1 is worth half as much as token0
+        prices = oracle.exposed_normalizePrices(2000e18, 1000e18);
+        assertEq(prices[0], 1e18, "First price should always be 1e18");
+        assertEq(prices[1], 0.5e18, "Token1 should be worth 0.5x token0");
+    }
+
+    function test_normalizePrices_DifferentDecimals() public {
+        reinitOracle(18, 6);
+        // Test with different decimals but same value
+        uint256[] memory prices = oracle.exposed_normalizePrices(1000e18, 1000e6);
+        assertEq(prices[0], 1e18, "First price should always be 1e18");
+        assertEq(prices[1], 1e18, "Equal values should result in 1e18 despite different decimals");
+    }
+
+    function test_normalizePrices_ExtremeValues() public view {
+        // This is expected because the decimals are more than 18 digits apart (which is the contract max).
+        uint256[] memory prices = oracle.exposed_normalizePrices(1_000_003_000_000_000_000_000_001, 1_000_000);
+        assertEq(prices[0], 1e18, "First price should always be 1e18");
+        assertEq(prices[1], 0, "Second price should be 0");
+    }
+
+    function testFuzz_normalizePrices(uint256 price0, uint256 price1) public view {
+        // Bound inputs to within 18 decimal places apart.
+        price0 = bound(price0, 1e6, 1e24);
+        price1 = bound(price1, 1e6, 1e24);
+
+        // Add debug logs to verify bounds
+        console.log("price0", price0);
+        console.log("price1", price1);
+
+        uint256[] memory prices = oracle.exposed_normalizePrices(price0, price1);
+
+        // Invariants that should always hold
+        assertEq(prices[0], 1e18, "First price should always be 1e18");
+        assertTrue(prices[1] > 0, "Second price should be positive");
+
+        // Verify relative price relationship
+        assertApproxEqRel(
+            prices[1],
+            (price1 * 1e18) / price0,
+            1e16, // 1% tolerance
+            "Relative price calculation incorrect"
+        );
     }
 }


### PR DESCRIPTION
This PR introduces `_simulateOrder`. For this we had to add in constructor arguments that are utilized in the function's logic. When testing, it became clear that there should be an additional function `_normalizePrices` which is also introduced here and unit tested. 
Additionally, we introduce a BaseTest that runs generic setup for the LPOracle contract wihle mocking some of the calls made in the constructor. Some utility methods are added for easy adjustments in unit tests. 

Another benefit of `normalizePrices` is that this now isolates ALL decimal related logic within the entire contract. All future methods introduced will no longer need to test against various token decimals.

## Implementation Decisions

The contract stores the token decimals as a gas optimization (reading of external contracts) since the pool and tokens are immutable. ⚠️ This could be an issue if some token's "decimals" were mutable. ⚠️ 

## Test Plan

Unit tests for _normalizePrices

Not sure if it makes sense to add a simulateOrder test since it only calls the tested normalize prices and then calls into an existing (presumably tested) contract. Let me know what you think @lumoswiz.

## Other Notes

Something is a bit off about decimals.

`adjustDecimals` takes arbitrary decimals, while `normalizePrices` uses the contract's fixed decimals. We may want to address this here.
 