### PR TITLE
refactor: reorganize test structure and improve test utilities

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -4,11 +4,19 @@
     "code-complexity": ["error", 8],
     "compiler-version": ["error", ">=0.8.25"],
     "func-name-mixedcase": "off",
-    "func-visibility": ["error", { "ignoreConstructors": true }],
+    "func-visibility": [
+      "error",
+      {
+        "ignoreConstructors": true
+      }
+    ],
     "max-line-length": ["error", 120],
     "named-parameters-mapping": "warn",
     "no-console": "off",
     "not-rely-on-time": "off",
-    "one-contract-per-file": "off"
+    "one-contract-per-file": "off",
+    "contract-name-camelcase": "off",
+    "var-name-mixedcase": "off",
+    "immutable-vars-naming": "off"
   }
 }

--- a/src/LPOracle.sol
+++ b/src/LPOracle.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.25;
 
 import { ICOWAMMPoolHelper } from "@cow-amm/interfaces/ICOWAMMPoolHelper.sol";

--- a/test/Base.t.sol
+++ b/test/Base.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity 0.8.25;
+pragma solidity >=0.8.25 < 0.9.0;
 
-import { Test } from "forge-std/Test.sol";
+import { Utils } from "test/utils/Utils.sol";
 import { ExposedLPOracle } from "test/harness/ExposedLPOracle.sol";
 
-abstract contract BaseTest is Test {
+contract BaseTest is Utils {
     address internal constant MOCK_HELPER = address(1);
     address internal constant MOCK_POOL = address(2);
     address internal constant TOKEN0 = address(0x1111111111111111111111111111111111111111);
@@ -22,13 +22,8 @@ abstract contract BaseTest is Test {
     }
 
     function setTokenDecimals(uint8 decimals0, uint8 decimals1) internal {
-        // Setup token addresses
-        address[] memory tokens = new address[](2);
-        tokens[0] = TOKEN0;
-        tokens[1] = TOKEN1;
-
         // Mock helper.tokens() call
-        vm.mockCall(MOCK_HELPER, abi.encodeWithSignature("tokens(address)", MOCK_POOL), abi.encode(tokens));
+        mock_call_tokens(MOCK_HELPER, MOCK_POOL, TOKEN0, TOKEN1);
 
         // Mock decimals() calls for both tokens
         vm.mockCall(TOKEN0, abi.encodeWithSignature("decimals()"), abi.encode(decimals0));

--- a/test/Base.t.sol
+++ b/test/Base.t.sol
@@ -1,25 +1,19 @@
-// SPDX-License-Identifier: GPL-3.0
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.8.25 < 0.9.0;
 
 import { Utils } from "test/utils/Utils.sol";
+import { Defaults } from "test/utils/Defaults.sol";
 import { ExposedLPOracle } from "test/harness/ExposedLPOracle.sol";
 import { MockBCoWHelper } from "test/mocks/MockBCoWHelper.sol";
 
-contract BaseTest is Utils {
+contract BaseTest is Defaults, Utils {
     address internal MOCK_POOL = makeAddr("MOCK_POOL");
     address internal MOCK_FACTORY = makeAddr("MOCK_FACTORY");
-    address internal constant TOKEN0 = address(0x1111111111111111111111111111111111111111);
-    address internal constant TOKEN1 = address(0x2222222222222222222222222222222222222222);
-
-    uint256 internal constant TOKEN0_BALANCE = 1e18;
-    uint256 internal constant TOKEN1_BALANCE = 1e18;
-    uint256 internal constant NORMALIZED_WEIGHT = 0.5e18;
-    uint256 internal constant DENORMALIZED_WEIGHT = 1e18;
-    bytes32 internal constant APP_DATA = keccak256("APP_DATA");
+    address internal TOKEN0 = makeAddr("TOKEN0");
+    address internal TOKEN1 = makeAddr("TOKEN1");
 
     ExposedLPOracle internal oracle;
     MockBCoWHelper internal helper;
-    // MockBCoWPool internal pool;
 
     function setUp() public virtual {
         // Mock BCoWFactory.APP_DATA() call
@@ -31,6 +25,7 @@ contract BaseTest is Utils {
 
         // Setup default token configuration with 18 decimals
         setTokenDecimals(18, 18);
+
         // Initialize oracle with default configuration
         oracle = new ExposedLPOracle(MOCK_POOL, address(helper));
         vm.label(address(oracle), "ExposedLPOracle");
@@ -41,8 +36,8 @@ contract BaseTest is Utils {
         mock_helper_tokens(address(helper), MOCK_POOL, TOKEN0, TOKEN1);
 
         // Mock decimals() calls for both tokens
-        vm.mockCall(TOKEN0, abi.encodeWithSignature("decimals()"), abi.encode(decimals0));
-        vm.mockCall(TOKEN1, abi.encodeWithSignature("decimals()"), abi.encode(decimals1));
+        mock_address_decimals(TOKEN0, decimals0);
+        mock_address_decimals(TOKEN1, decimals1);
     }
 
     // Helper to reinitialize oracle after changing decimals

--- a/test/Base.t.sol
+++ b/test/Base.t.sol
@@ -3,27 +3,42 @@ pragma solidity >=0.8.25 < 0.9.0;
 
 import { Utils } from "test/utils/Utils.sol";
 import { ExposedLPOracle } from "test/harness/ExposedLPOracle.sol";
+import { MockBCoWHelper } from "test/mocks/MockBCoWHelper.sol";
 
 contract BaseTest is Utils {
-    address internal constant MOCK_HELPER = address(1);
-    address internal constant MOCK_POOL = address(2);
+    address internal MOCK_POOL = makeAddr("MOCK_POOL");
+    address internal MOCK_FACTORY = makeAddr("MOCK_FACTORY");
     address internal constant TOKEN0 = address(0x1111111111111111111111111111111111111111);
     address internal constant TOKEN1 = address(0x2222222222222222222222222222222222222222);
 
+    uint256 internal constant TOKEN0_BALANCE = 1e18;
+    uint256 internal constant TOKEN1_BALANCE = 1e18;
+    uint256 internal constant NORMALIZED_WEIGHT = 0.5e18;
+    uint256 internal constant DENORMALIZED_WEIGHT = 1e18;
+    bytes32 internal constant APP_DATA = keccak256("APP_DATA");
+
     ExposedLPOracle internal oracle;
+    MockBCoWHelper internal helper;
+    // MockBCoWPool internal pool;
 
     function setUp() public virtual {
+        // Mock BCoWFactory.APP_DATA() call
+        mock_factory_APP_DATA(MOCK_FACTORY, APP_DATA);
+
+        // Deploy MockBCoWHelper with default configuration
+        helper = new MockBCoWHelper(MOCK_FACTORY);
+        vm.label(address(helper), "MockBCoWHelper");
+
         // Setup default token configuration with 18 decimals
         setTokenDecimals(18, 18);
         // Initialize oracle with default configuration
-        oracle = new ExposedLPOracle(MOCK_POOL, MOCK_HELPER);
-        // Label for stack traces
+        oracle = new ExposedLPOracle(MOCK_POOL, address(helper));
         vm.label(address(oracle), "ExposedLPOracle");
     }
 
     function setTokenDecimals(uint8 decimals0, uint8 decimals1) internal {
         // Mock helper.tokens() call
-        mock_call_tokens(MOCK_HELPER, MOCK_POOL, TOKEN0, TOKEN1);
+        mock_helper_tokens(address(helper), MOCK_POOL, TOKEN0, TOKEN1);
 
         // Mock decimals() calls for both tokens
         vm.mockCall(TOKEN0, abi.encodeWithSignature("decimals()"), abi.encode(decimals0));
@@ -33,6 +48,6 @@ contract BaseTest is Utils {
     // Helper to reinitialize oracle after changing decimals
     function reinitOracle(uint8 decimals0, uint8 decimals1) internal {
         setTokenDecimals(decimals0, decimals1);
-        oracle = new ExposedLPOracle(MOCK_POOL, MOCK_HELPER);
+        oracle = new ExposedLPOracle(MOCK_POOL, address(helper));
     }
 }

--- a/test/Base.t.sol
+++ b/test/Base.t.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.25;
+
+import { Test } from "forge-std/Test.sol";
+import { ExposedLPOracle } from "test/harness/ExposedLPOracle.sol";
+
+abstract contract BaseTest is Test {
+    address internal constant MOCK_HELPER = address(1);
+    address internal constant MOCK_POOL = address(2);
+    address internal constant TOKEN0 = address(0x1111111111111111111111111111111111111111);
+    address internal constant TOKEN1 = address(0x2222222222222222222222222222222222222222);
+
+    ExposedLPOracle internal oracle;
+
+    function setUp() public virtual {
+        // Setup default token configuration with 18 decimals
+        setTokenDecimals(18, 18);
+        // Initialize oracle with default configuration
+        oracle = new ExposedLPOracle(MOCK_POOL, MOCK_HELPER);
+        // Label for stack traces
+        vm.label(address(oracle), "ExposedLPOracle");
+    }
+
+    function setTokenDecimals(uint8 decimals0, uint8 decimals1) internal {
+        // Setup token addresses
+        address[] memory tokens = new address[](2);
+        tokens[0] = TOKEN0;
+        tokens[1] = TOKEN1;
+
+        // Mock helper.tokens() call
+        vm.mockCall(MOCK_HELPER, abi.encodeWithSignature("tokens(address)", MOCK_POOL), abi.encode(tokens));
+
+        // Mock decimals() calls for both tokens
+        vm.mockCall(TOKEN0, abi.encodeWithSignature("decimals()"), abi.encode(decimals0));
+        vm.mockCall(TOKEN1, abi.encodeWithSignature("decimals()"), abi.encode(decimals1));
+    }
+
+    // Helper to reinitialize oracle after changing decimals
+    function reinitOracle(uint8 decimals0, uint8 decimals1) internal {
+        setTokenDecimals(decimals0, decimals1);
+        oracle = new ExposedLPOracle(MOCK_POOL, MOCK_HELPER);
+    }
+}

--- a/test/harness/ExposedLPOracle.sol
+++ b/test/harness/ExposedLPOracle.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.25;
 
 import { LPOracle } from "src/LPOracle.sol";

--- a/test/harness/ExposedLPOracle.sol
+++ b/test/harness/ExposedLPOracle.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.25;
+
+import { LPOracle } from "src/LPOracle.sol";
+import { GPv2Order } from "cowprotocol/contracts/libraries/GPv2Order.sol";
+
+contract ExposedLPOracle is LPOracle {
+    constructor(address _pool, address _helper) LPOracle(_pool, _helper) { }
+
+    function exposed_simulateOrder(uint256 price0, uint256 price1) external view returns (GPv2Order.Data memory) {
+        return _simulateOrder(price0, price1);
+    }
+
+    function exposed_normalizePrices(uint256 price0, uint256 price1) external view returns (uint256[] memory) {
+        return _normalizePrices(price0, price1);
+    }
+
+    function exposed_adjustDecimals(
+        uint256 value0,
+        uint256 value1,
+        uint8 decimals0,
+        uint8 decimals1
+    )
+        external
+        pure
+        returns (uint256 adjusted0, uint256 adjusted1)
+    {
+        return _adjustDecimals(value0, value1, decimals0, decimals1);
+    }
+}

--- a/test/mocks/MockBCoWHelper.sol
+++ b/test/mocks/MockBCoWHelper.sol
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity >=0.8.25;
+
+import { BCoWConst } from "@balancer/cow-amm/src/contracts/BCoWConst.sol";
+import { BMath } from "@balancer/cow-amm/src/contracts/BMath.sol";
+import { GPv2Order } from "cowprotocol/contracts/libraries/GPv2Order.sol";
+import { GPv2Interaction } from "@cowprotocol/libraries/GPv2Interaction.sol";
+
+import { ICOWAMMPoolHelper } from "@cow-amm/interfaces/ICOWAMMPoolHelper.sol";
+import { IERC20 } from "cowprotocol/contracts/interfaces/IERC20.sol";
+
+import { IBCoWFactory } from "@balancer/cow-amm/src/interfaces/IBCoWFactory.sol";
+import { IBCoWPool } from "@balancer/cow-amm/src/interfaces/IBCoWPool.sol";
+
+/// @dev Adapted from BCoWHelper modified to expose `order` functionality without _prepareSettlement
+contract MockBCoWHelper is ICOWAMMPoolHelper, BMath, BCoWConst {
+    /**
+     * @dev Collection of pool information on a specific token
+     * @param token The token all fields depend on
+     * @param balance The pool balance for the token
+     * @param denormWeight Denormalized weight of the token
+     * @param normWeight Normalized weight of the token
+     */
+    struct Reserves {
+        IERC20 token;
+        uint256 balance;
+        uint256 denormWeight;
+        uint256 normWeight;
+    }
+
+    /// @notice The app data used by this helper's factory.
+    bytes32 internal immutable _APP_DATA;
+
+    /// @inheritdoc ICOWAMMPoolHelper
+    // solhint-disable-next-line style-guide-casing
+    address public immutable factory;
+
+    /// @notice The input token to the call is not traded on the pool.
+    error InvalidToken();
+
+    constructor(address factory_) {
+        factory = factory_;
+        _APP_DATA = IBCoWFactory(factory_).APP_DATA();
+    }
+
+    function order(
+        address pool,
+        uint256[] calldata prices
+    )
+        external
+        view
+        returns (
+            GPv2Order.Data memory order_,
+            GPv2Interaction.Data[] memory preInteractions,
+            GPv2Interaction.Data[] memory postInteractions,
+            bytes memory sig
+        )
+    {
+        address[] memory tokenPair = tokens(pool);
+        Reserves memory reservesToken0 = _reserves(IBCoWPool(pool), IERC20(tokenPair[0]));
+        Reserves memory reservesToken1 = _reserves(IBCoWPool(pool), IERC20(tokenPair[1]));
+
+        (Reserves memory reservesIn, uint256 amountIn, Reserves memory reservesOut) =
+            _amountInFromPrices(reservesToken0, reservesToken1, prices);
+
+        return _orderFromBuyAmount(pool, reservesIn, amountIn, reservesOut);
+    }
+
+    function _orderFromBuyAmount(
+        address,
+        Reserves memory reservesIn,
+        uint256 amountIn,
+        Reserves memory reservesOut
+    )
+        internal
+        view
+        returns (
+            GPv2Order.Data memory order_,
+            GPv2Interaction.Data[] memory preInteractions,
+            GPv2Interaction.Data[] memory postInteractions,
+            bytes memory sig
+        )
+    {
+        order_ = _rawOrderFrom(reservesIn, amountIn, reservesOut);
+        // explicit return
+        return (order_, preInteractions, postInteractions, sig);
+        // (preInteractions, postInteractions, sig) = _prepareSettlement(pool, order_);
+    }
+
+    /// @notice Returns the order that is suggested to be executed to CoW Protocol
+    /// for specific reserves of a pool given the current chain state and the
+    /// traded amount. The price of the order is on the AMM curve for the traded
+    /// amount.
+    /// @dev This function takes an input amount and guarantees that the final
+    /// order has that input amount and is a valid order. We use `calcOutGivenIn`
+    /// to compute the output amount as this is the function used to check that
+    /// the CoW Swap order is valid in the contract. It would not be possible to
+    /// just define the same function by specifying an output amount and use
+    /// `calcInGiveOut`: because of rounding issues the resulting order could be
+    /// invalid.
+    /// @param reservesIn Data related to the input token of this trade
+    /// @param amountIn Token amount moving into the pool for this order
+    /// @param reservesOut Data related to the output token of this trade
+    /// @return order_ The CoW Protocol JIT order
+    function _rawOrderFrom(
+        Reserves memory reservesIn,
+        uint256 amountIn,
+        Reserves memory reservesOut
+    )
+        internal
+        view
+        returns (GPv2Order.Data memory order_)
+    {
+        uint256 amountOut = calcOutGivenIn({
+            tokenBalanceIn: reservesIn.balance,
+            tokenWeightIn: reservesIn.denormWeight,
+            tokenBalanceOut: reservesOut.balance,
+            tokenWeightOut: reservesOut.denormWeight,
+            tokenAmountIn: amountIn,
+            swapFee: 0
+        });
+        return GPv2Order.Data({
+            sellToken: reservesOut.token,
+            buyToken: reservesIn.token,
+            receiver: GPv2Order.RECEIVER_SAME_AS_OWNER,
+            sellAmount: amountOut,
+            buyAmount: amountIn,
+            validTo: uint32(block.timestamp) + MAX_ORDER_DURATION,
+            appData: bytes32(0),
+            feeAmount: 0,
+            kind: GPv2Order.KIND_SELL,
+            partiallyFillable: true,
+            sellTokenBalance: GPv2Order.BALANCE_ERC20,
+            buyTokenBalance: GPv2Order.BALANCE_ERC20
+        });
+    }
+
+    /// @notice Returns which trade is suggested to be executed on CoW Protocol
+    /// for specific reserves of a pool given the current chain state and prices
+    /// @param reservesToken0 Data related to the first token traded in the pool
+    /// @param reservesToken1 Data related to the second token traded in the pool
+    /// @param prices supplied for determining the order; the format is specified
+    /// in the `order` function
+    /// @return reservesIn Data related to the input token in the trade
+    /// @return amountIn How much input token should be trated
+    /// @return reservesOut Data related to the input token in the trade
+    function _amountInFromPrices(
+        Reserves memory reservesToken0,
+        Reserves memory reservesToken1,
+        uint256[] calldata prices
+    )
+        internal
+        pure
+        returns (Reserves memory reservesIn, uint256 amountIn, Reserves memory reservesOut)
+    {
+        reservesOut = reservesToken0;
+        reservesIn = reservesToken1;
+
+        // The out amount is computed according to the following formula:
+        // aO = amountOut
+        // bI = reservesIn.balance                   bO * wI - p * bI * wO
+        // bO = reservesOut.balance            aO =  ---------------------
+        // wI = reservesIn.denormWeight                     wI + wO
+        // wO = reservesOut.denormWeight
+        // p  = priceNumerator / priceDenominator
+        //
+        // Note that in the code we use normalized weights instead of computing the
+        // full expression from raw weights. Since BCoW pools support only two
+        // tokens, this is equivalent to assuming that wI + wO = 1.
+
+        // The price of this function is expressed as amount of token1 per amount
+        // of token0. The `prices` vector is expressed the other way around, as
+        // confirmed by dimensional analysis of the expression above.
+        uint256 priceNumerator = prices[1]; // x token = sell token = out amount
+        uint256 priceDenominator = prices[0];
+        uint256 balanceOutTimesWeightIn = bmul(reservesOut.balance, reservesIn.normWeight);
+        uint256 balanceInTimesWeightOut = bmul(reservesIn.balance, reservesOut.normWeight);
+
+        // This check compares the (weight-adjusted) pool spot price with the input
+        // price. The formula for the pool's spot price can be found in the
+        // definition of `calcSpotPrice`, assuming no swap fee. The comparison is
+        // derived from the following expression:
+        //
+        //       priceNumerator    bO / wO      /   bO * wI  \
+        //      ---------------- > -------     |  = -------   |
+        //      priceDenominator   bI / wI      \   bI * wO  /
+        //
+        // This inequality also guarantees that the amount out is positive: the
+        // amount out is positive if and only if this inequality is false, meaning
+        // that if the following condition matches then we want to invert the sell
+        // and buy tokens.
+        if (bmul(balanceInTimesWeightOut, priceNumerator) > bmul(balanceOutTimesWeightIn, priceDenominator)) {
+            (reservesOut, reservesIn) = (reservesIn, reservesOut);
+            (balanceOutTimesWeightIn, balanceInTimesWeightOut) = (balanceInTimesWeightOut, balanceOutTimesWeightIn);
+            (priceNumerator, priceDenominator) = (priceDenominator, priceNumerator);
+        }
+        uint256 par = bdiv(bmul(balanceInTimesWeightOut, priceNumerator), priceDenominator);
+        uint256 amountOut = balanceOutTimesWeightIn - par;
+        amountIn = calcInGivenOut({
+            tokenBalanceIn: reservesIn.balance,
+            tokenWeightIn: reservesIn.denormWeight,
+            tokenBalanceOut: reservesOut.balance,
+            tokenWeightOut: reservesOut.denormWeight,
+            tokenAmountOut: amountOut,
+            swapFee: 0
+        });
+    }
+
+    /// @inheritdoc ICOWAMMPoolHelper
+    function tokens(address pool) public view virtual returns (address[] memory tokens_) {
+        // reverts in case pool is not deployed by the helper's factory
+        if (!IBCoWFactory(factory).isBPool(pool)) {
+            revert PoolDoesNotExist();
+        }
+
+        // call reverts with `BPool_PoolNotFinalized()` in case pool is not finalized
+        tokens_ = IBCoWPool(pool).getFinalTokens();
+
+        // reverts in case pool is not supported (non-2-token pool)
+        if (tokens_.length != 2) {
+            revert PoolDoesNotExist();
+        }
+    }
+
+    /// @notice Returns information on pool reserves for a specific pool and token
+    /// @dev This is mostly used for the readability of grouping all parameters
+    /// relative to the same token are grouped together in the same variable
+    /// @param pool The pool with the funds
+    /// @param token The token on which to recover information
+    /// @return Parameters relative to the token reserves in the pool
+    function _reserves(IBCoWPool pool, IERC20 token) internal view returns (Reserves memory) {
+        uint256 balance = token.balanceOf(address(pool));
+        uint256 normalizedWeight = pool.getNormalizedWeight(address(token));
+        uint256 denormalizedWeight = pool.getDenormalizedWeight(address(token));
+        return
+            Reserves({ token: token, balance: balance, denormWeight: denormalizedWeight, normWeight: normalizedWeight });
+    }
+}

--- a/test/mocks/MockBCoWHelper.sol
+++ b/test/mocks/MockBCoWHelper.sol
@@ -12,7 +12,7 @@ import { IERC20 } from "cowprotocol/contracts/interfaces/IERC20.sol";
 import { IBCoWFactory } from "@balancer/cow-amm/src/interfaces/IBCoWFactory.sol";
 import { IBCoWPool } from "@balancer/cow-amm/src/interfaces/IBCoWPool.sol";
 
-/// @dev Adapted from BCoWHelper modified to expose `order` functionality without _prepareSettlement
+/// @dev Adapted from BCoWHelper modified to expose `order` without _prepareSettlement
 contract MockBCoWHelper is ICOWAMMPoolHelper, BMath, BCoWConst {
     /**
      * @dev Collection of pool information on a specific token
@@ -233,6 +233,7 @@ contract MockBCoWHelper is ICOWAMMPoolHelper, BMath, BCoWConst {
         uint256 normalizedWeight = pool.getNormalizedWeight(address(token));
         uint256 denormalizedWeight = pool.getDenormalizedWeight(address(token));
         return
-            Reserves({ token: token, balance: balance, denormWeight: denormalizedWeight, normWeight: normalizedWeight });
+        // solhint-disable-next-line max-line-length
+        Reserves({ token: token, balance: balance, denormWeight: denormalizedWeight, normWeight: normalizedWeight });
     }
 }

--- a/test/unit/AdjustDecimals.t.sol
+++ b/test/unit/AdjustDecimals.t.sol
@@ -1,9 +1,9 @@
-// SPDX-License-Identifier: GPL-3.0
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.25;
 
 import { BaseTest } from "test/Base.t.sol";
 
-contract TestLPOracle is BaseTest {
+contract AdjustDecimals_Unit_Test is BaseTest {
     function test_adjustDecimals_SameDecimals() public view {
         (uint256 adjusted0, uint256 adjusted1) = oracle.exposed_adjustDecimals(
             100, // value0
@@ -93,62 +93,5 @@ contract TestLPOracle is BaseTest {
             assertEq(adjusted0, value0);
             assertEq(adjusted1, value1);
         }
-    }
-
-    function test_normalizePrices() public view {
-        // Using default oracle configuration (18 decimals for both tokens)
-        // Test case where both tokens have and same price
-        uint256[] memory prices = oracle.exposed_normalizePrices(1000e18, 1000e18);
-        assertEq(prices[0], 1e18, "First price should always be 1e18");
-        assertEq(prices[1], 1e18, "Equal prices should result in 1e18");
-
-        // Test case where token1 is worth twice as much as token0
-        prices = oracle.exposed_normalizePrices(1000e18, 2000e18);
-        assertEq(prices[0], 1e18, "First price should always be 1e18");
-        assertEq(prices[1], 2e18, "Token1 should be worth 2x token0");
-
-        // Test case where token1 is worth half as much as token0
-        prices = oracle.exposed_normalizePrices(2000e18, 1000e18);
-        assertEq(prices[0], 1e18, "First price should always be 1e18");
-        assertEq(prices[1], 0.5e18, "Token1 should be worth 0.5x token0");
-    }
-
-    function test_normalizePrices_DifferentDecimals() public {
-        reinitOracle(18, 6);
-        // Test with different decimals but same value
-        uint256[] memory prices = oracle.exposed_normalizePrices(1000e18, 1000e6);
-        assertEq(prices[0], 1e18, "First price should always be 1e18");
-        assertEq(prices[1], 1e18, "Equal values should result in 1e18 despite different decimals");
-    }
-
-    function test_normalizePrices_ExtremeValues() public view {
-        // This is expected because the decimals are more than 18 digits apart (which is the contract max).
-        uint256[] memory prices = oracle.exposed_normalizePrices(1_000_003_000_000_000_000_000_001, 1_000_000);
-        assertEq(prices[0], 1e18, "First price should always be 1e18");
-        assertEq(prices[1], 0, "Second price should be 0");
-    }
-
-    function testFuzz_normalizePrices(uint256 price0, uint256 price1) public {
-        // Bound inputs to within 18 decimal places apart.
-        price0 = bound(price0, 1e6, 1e24);
-        price1 = bound(price1, 1e6, 1e24);
-
-        // Add debug logs to verify bounds
-        emit log_named_uint("price0", price0);
-        emit log_named_uint("price1", price1);
-
-        uint256[] memory prices = oracle.exposed_normalizePrices(price0, price1);
-
-        // Invariants that should always hold
-        assertEq(prices[0], 1e18, "First price should always be 1e18");
-        assertTrue(prices[1] > 0, "Second price should be positive");
-
-        // Verify relative price relationship
-        assertApproxEqRel(
-            prices[1],
-            (price1 * 1e18) / price0,
-            1e16, // 1% tolerance
-            "Relative price calculation incorrect"
-        );
     }
 }

--- a/test/unit/NormalizePrices.t.sol
+++ b/test/unit/NormalizePrices.t.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.25;
+
+import { BaseTest } from "test/Base.t.sol";
+
+contract NormalizePrices_Unit_Test is BaseTest {
+    function test_normalizePrices() public view {
+        // Using default oracle configuration (18 decimals for both tokens)
+        // Test case where both tokens have and same price
+        uint256[] memory prices = oracle.exposed_normalizePrices(1000e18, 1000e18);
+        assertEq(prices[0], 1e18, "First price should always be 1e18");
+        assertEq(prices[1], 1e18, "Equal prices should result in 1e18");
+
+        // Test case where token1 is worth twice as much as token0
+        prices = oracle.exposed_normalizePrices(1000e18, 2000e18);
+        assertEq(prices[0], 1e18, "First price should always be 1e18");
+        assertEq(prices[1], 2e18, "Token1 should be worth 2x token0");
+
+        // Test case where token1 is worth half as much as token0
+        prices = oracle.exposed_normalizePrices(2000e18, 1000e18);
+        assertEq(prices[0], 1e18, "First price should always be 1e18");
+        assertEq(prices[1], 0.5e18, "Token1 should be worth 0.5x token0");
+    }
+
+    function test_normalizePrices_DifferentDecimals() public {
+        reinitOracle(18, 6);
+        // Test with different decimals but same value
+        uint256[] memory prices = oracle.exposed_normalizePrices(1000e18, 1000e6);
+        assertEq(prices[0], 1e18, "First price should always be 1e18");
+        assertEq(prices[1], 1e18, "Equal values should result in 1e18 despite different decimals");
+    }
+
+    function test_normalizePrices_ExtremeValues() public view {
+        // This is expected because the decimals are more than 18 digits apart (which is the contract max).
+        uint256[] memory prices = oracle.exposed_normalizePrices(1_000_003_000_000_000_000_000_001, 1_000_000);
+        assertEq(prices[0], 1e18, "First price should always be 1e18");
+        assertEq(prices[1], 0, "Second price should be 0");
+    }
+
+    function testFuzz_normalizePrices(uint256 price0, uint256 price1) public {
+        // Bound inputs to within 18 decimal places apart.
+        price0 = bound(price0, 1e6, 1e24);
+        price1 = bound(price1, 1e6, 1e24);
+
+        // Add debug logs to verify bounds
+        emit log_named_uint("price0", price0);
+        emit log_named_uint("price1", price1);
+
+        uint256[] memory prices = oracle.exposed_normalizePrices(price0, price1);
+
+        // Invariants that should always hold
+        assertEq(prices[0], 1e18, "First price should always be 1e18");
+        assertTrue(prices[1] > 0, "Second price should be positive");
+
+        // Verify relative price relationship
+        assertApproxEqRel(
+            prices[1],
+            (price1 * 1e18) / price0,
+            1e16, // 1% tolerance
+            "Relative price calculation incorrect"
+        );
+    }
+}

--- a/test/utils/Defaults.sol
+++ b/test/utils/Defaults.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity >=0.8.25 < 0.9.0;
+
+contract Defaults {
+    uint256 internal constant TOKEN0_BALANCE = 1e18;
+    uint256 internal constant TOKEN1_BALANCE = 1e18;
+    uint256 internal constant NORMALIZED_WEIGHT = 0.5e18;
+    uint256 internal constant DENORMALIZED_WEIGHT = 1e18;
+    bytes32 internal constant APP_DATA = keccak256("APP_DATA");
+}

--- a/test/utils/Types.sol
+++ b/test/utils/Types.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity >=0.8.25;
+
+struct TokenParams {
+    address addr;
+    uint256 balance;
+    uint256 normWeight;
+    uint256 denormWeight;
+}
+
+struct OrderParams {
+    address pool;
+    address factory;
+    TokenParams token0;
+    TokenParams token1;
+    bytes32 domainSeparator;
+}

--- a/test/utils/Utils.sol
+++ b/test/utils/Utils.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.8.25 < 0.9.0;
+
+import { Test } from "forge-std/Test.sol";
+
+contract Utils is Test {
+    /*----------------------------------------------------------*|
+    |*  # MOCK CALLS: BCoWHelper                                *|
+    |*----------------------------------------------------------*/
+    function mock_call_tokens(address helper, address pool, address token0, address token1) internal {
+        // Setup token addresses
+        address[] memory tokens = new address[](2);
+        tokens[0] = token0;
+        tokens[1] = token1;
+
+        // Mock helper.tokens() call
+        vm.mockCall(helper, abi.encodeWithSignature("tokens(address)", pool), abi.encode(tokens));
+    }
+}

--- a/test/utils/Utils.sol
+++ b/test/utils/Utils.sol
@@ -2,12 +2,45 @@
 pragma solidity >=0.8.25 < 0.9.0;
 
 import { Test } from "forge-std/Test.sol";
+import { OrderParams } from "test/utils/Types.sol";
 
 contract Utils is Test {
     /*----------------------------------------------------------*|
+    |*  # MOCK CALLS: ERC20                                     *|
+    |*----------------------------------------------------------*/
+
+    function mock_token_balanceOf(address token, address pool, uint256 balance) internal {
+        vm.mockCall(token, abi.encodeWithSignature("balanceOf(address)", pool), abi.encode(balance));
+    }
+
+    /*----------------------------------------------------------*|
+    |*  # MOCK CALLS: BCoWPool                                 *|
+    |*----------------------------------------------------------*/
+
+    function mock_pool_getNormalizedWeight(address pool, address token, uint256 normWeight) internal {
+        vm.mockCall(pool, abi.encodeWithSignature("getNormalizedWeight(address)", token), abi.encode(normWeight));
+    }
+
+    function mock_pool_getDenormalizedWeight(address pool, address token, uint256 denormWeight) internal {
+        vm.mockCall(pool, abi.encodeWithSignature("getDenormalizedWeight(address)", token), abi.encode(denormWeight));
+    }
+
+    function mock_pool_getFinalTokens(address pool, address token0, address token1) internal {
+        address[] memory tokens = new address[](2);
+        tokens[0] = token0;
+        tokens[1] = token1;
+
+        vm.mockCall(pool, abi.encodeWithSignature("getFinalTokens()"), abi.encode(tokens));
+    }
+
+    function mock_pool__finalized(address pool) internal {
+        vm.mockCall(pool, abi.encodeWithSignature("_finalized()"), abi.encode(true));
+    }
+
+    /*----------------------------------------------------------*|
     |*  # MOCK CALLS: BCoWHelper                                *|
     |*----------------------------------------------------------*/
-    function mock_call_tokens(address helper, address pool, address token0, address token1) internal {
+    function mock_helper_tokens(address helper, address pool, address token0, address token1) internal {
         // Setup token addresses
         address[] memory tokens = new address[](2);
         tokens[0] = token0;
@@ -15,5 +48,49 @@ contract Utils is Test {
 
         // Mock helper.tokens() call
         vm.mockCall(helper, abi.encodeWithSignature("tokens(address)", pool), abi.encode(tokens));
+    }
+
+    function mock_helper_reserves(
+        address pool,
+        address token,
+        uint256 balance,
+        uint256 normWeight,
+        uint256 denormWeight
+    )
+        internal
+    {
+        mock_token_balanceOf(token, pool, balance);
+        mock_pool_getNormalizedWeight(pool, token, normWeight);
+        mock_pool_getDenormalizedWeight(pool, token, denormWeight);
+    }
+
+    function mock_helper_order(OrderParams memory params) internal {
+        // Mock BCoWFactory.isBPool
+        mock_factory_isBPool(params.factory, params.pool);
+
+        // Mock BCowPool.getFinalTokens
+        mock_pool_getFinalTokens(params.pool, params.token0.addr, params.token1.addr);
+
+        // Mocks helper._reserves for token0
+        mock_helper_reserves(
+            params.pool, params.token0.addr, params.token0.balance, params.token0.normWeight, params.token0.denormWeight
+        );
+
+        // Mocks helper._reserves for token1
+        mock_helper_reserves(
+            params.pool, params.token1.addr, params.token1.balance, params.token1.normWeight, params.token1.denormWeight
+        );
+    }
+
+    /*----------------------------------------------------------*|
+    |*  # MOCK CALLS: BCoWFactory                               *|
+    |*----------------------------------------------------------*/
+
+    function mock_factory_APP_DATA(address factory, bytes32 data) internal {
+        vm.mockCall(factory, abi.encodeWithSignature("APP_DATA()"), abi.encode(data));
+    }
+
+    function mock_factory_isBPool(address factory, address pool) internal {
+        vm.mockCall(factory, abi.encodeWithSignature("isBPool(address)", pool), abi.encode(true));
     }
 }

--- a/test/utils/Utils.sol
+++ b/test/utils/Utils.sol
@@ -1,10 +1,18 @@
-// SPDX-License-Identifier: GPL-3.0
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.8.25 < 0.9.0;
 
 import { Test } from "forge-std/Test.sol";
 import { OrderParams } from "test/utils/Types.sol";
 
 contract Utils is Test {
+    /*----------------------------------------------------------*|
+    |*  # MOCK CALLS: SHARED                                    *|
+    |*----------------------------------------------------------*/
+
+    function mock_address_decimals(address addr, uint8 decimals) internal {
+        vm.mockCall(addr, abi.encodeWithSignature("decimals()"), abi.encode(decimals));
+    }
+
     /*----------------------------------------------------------*|
     |*  # MOCK CALLS: ERC20                                     *|
     |*----------------------------------------------------------*/


### PR DESCRIPTION
This PR refactors the test suite to improve organization and maintainability:

Structure Changes:
- Created harness/ and mocks/ directories for exposed/mocked contracts
- Split unit tests into separate files by functionality
- Reorganized test files into a clearer directory structure

Testing Infrastructure:
- Added mock contract call utils for testing
- Added MockBCoWHelper for isolated order testing by modifying BCoWHelper
- Added struct definitions for test functions in Types.sol
- Added Defaults.sol for centralized test constants

Quality Improvements:
- Standardized license headers across all files
- Modified inheritance chain: BaseTest -> Utils -> Test
- Added proper makeAddr usage to avoid precompile issues (e.g. address(1))

The changes make the test suite more modular and easier to maintain while providing better utilities for future test development.