### PR TITLE
test: add SimulateOrder tests

### DIFF
--- a/test/Base.t.sol
+++ b/test/Base.t.sol
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.8.25 < 0.9.0;
 
-import { Utils } from "test/utils/Utils.sol";
-import { Defaults } from "test/utils/Defaults.sol";
 import { ExposedLPOracle } from "test/harness/ExposedLPOracle.sol";
 import { MockBCoWHelper } from "test/mocks/MockBCoWHelper.sol";
+
+import { Utils } from "test/utils/Utils.sol";
+import { Defaults } from "test/utils/Defaults.sol";
+import { OrderParams, TokenParams } from "test/utils/Types.sol";
 
 contract BaseTest is Defaults, Utils {
     address internal MOCK_POOL = makeAddr("MOCK_POOL");
@@ -44,5 +46,26 @@ contract BaseTest is Defaults, Utils {
     function reinitOracle(uint8 decimals0, uint8 decimals1) internal {
         setTokenDecimals(decimals0, decimals1);
         oracle = new ExposedLPOracle(MOCK_POOL, address(helper));
+    }
+
+    function setMockOrder() internal {
+        OrderParams memory params = OrderParams({
+            pool: MOCK_POOL,
+            factory: MOCK_FACTORY,
+            token0: TokenParams({
+                addr: TOKEN0,
+                balance: TOKEN0_BALANCE,
+                normWeight: NORMALIZED_WEIGHT,
+                denormWeight: DENORMALIZED_WEIGHT
+            }),
+            token1: TokenParams({
+                addr: TOKEN1,
+                balance: TOKEN1_BALANCE,
+                normWeight: NORMALIZED_WEIGHT,
+                denormWeight: DENORMALIZED_WEIGHT
+            })
+        });
+
+        mock_helper_order(params);
     }
 }

--- a/test/unit/SimulateOrder.t.sol
+++ b/test/unit/SimulateOrder.t.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.25;
+
+import { BaseTest } from "test/Base.t.sol";
+import { GPv2Order } from "cowprotocol/contracts/libraries/GPv2Order.sol";
+
+contract SimulateOrder_Unit_Test is BaseTest {
+    function test_ShouldRevert_ZeroPrice0() external {
+        uint256 price0 = 0;
+        uint256 price1 = 1e8;
+
+        vm.expectRevert();
+        oracle.exposed_simulateOrder(price0, price1);
+    }
+
+    function test_ShouldRevert_ZeroPrice1() external {
+        uint256 price0 = 1e18;
+        uint256 price1 = 0;
+
+        vm.expectRevert();
+        oracle.exposed_simulateOrder(price0, price1);
+    }
+
+    modifier whenNonZeroPrices() {
+        _;
+    }
+
+    /// @dev Left this test here with no assertions in case we want to probe
+    function test_SimulateOrder() external whenNonZeroPrices {
+        // Setup mock order
+        setMockOrder();
+
+        // Set prices
+        uint256 price0 = 1.02e8;
+        uint256 price1 = 1e8;
+
+        // Call should succeed
+        GPv2Order.Data memory order = oracle.exposed_simulateOrder(price0, price1);
+    }
+}

--- a/test/utils/Types.sol
+++ b/test/utils/Types.sol
@@ -13,5 +13,4 @@ struct OrderParams {
     address factory;
     TokenParams token0;
     TokenParams token1;
-    bytes32 domainSeparator;
 }


### PR DESCRIPTION
Changes:
- Remove redundant domainSeparator from Types.OrderParams struct
- Add initial unit tests for _simulateOrder functionality