### PR TITLE
feat: initialize chainlink price feeds and add data retrieval

### DIFF
--- a/src/LPOracle.sol
+++ b/src/LPOracle.sol
@@ -42,7 +42,7 @@ contract LPOracle {
     /// @param _feed0 Chainlink USD price feed for pool token at index 0.
     /// @param _feed1 Chainlink USD price feed for pool token at index 1.
     constructor(address _pool, address _helper, address _feed0, address _feed1) {
-        /* Set price feeds & revert if feeds have greater than 18 decimals*/
+        /* Set price feeds & revert if feeds have greater than 18 decimals */
         FEED0 = AggregatorV3Interface(_feed0);
         FEED1 = AggregatorV3Interface(_feed1);
         if (FEED0.decimals() > 18 || FEED1.decimals() > 18) revert UnsupportedDecimals();

--- a/src/LPOracle.sol
+++ b/src/LPOracle.sol
@@ -60,6 +60,22 @@ contract LPOracle {
         TOKEN1_DECIMALS = TOKEN1.decimals();
     }
 
+    /// @notice Retrieves latest price data from Chainlink feeds and adjusts for decimals.
+    /// @return price0 USD price of token 0.
+    /// @return price1 USD price of token1.
+    /// @return updatedAt The timestamp of the feed with the oldest price udpate.
+    function _getFeedData() internal view returns (uint256 price0, uint256 price1, uint256 updatedAt) {
+        /* Get latestRoundData from price feeds */
+        (, int256 answer0,, uint256 updatedAt0,) = FEED0.latestRoundData();
+        (, int256 answer1,, uint256 updatedAt1,) = FEED1.latestRoundData();
+
+        /* Adjust answers for price feed decimals */
+        (price0, price1) = _adjustDecimals(uint256(answer0), uint256(answer1), FEED0.decimals(), FEED1.decimals());
+
+        /* Set update timestamp of oldest price feed */
+        updatedAt = updatedAt0 < updatedAt1 ? updatedAt0 : updatedAt1;
+    }
+
     /// @notice Retrieves the order to satisfy the pool's invariants given the token prices.
     /// @dev Zero fee constant function AMM.
     /// @dev Decimals for price0 and price1 should be identical.

--- a/test/Base.t.sol
+++ b/test/Base.t.sol
@@ -6,7 +6,7 @@ import { MockBCoWHelper } from "test/mocks/MockBCoWHelper.sol";
 
 import { Assertions } from "test/utils/Assertions.sol";
 import { Defaults } from "test/utils/Defaults.sol";
-import { OrderParams, TokenParams } from "test/utils/Types.sol";
+import { OrderParams, TokenParams, FeedParams } from "test/utils/Types.sol";
 import { Utils } from "test/utils/Utils.sol";
 
 contract BaseTest is Assertions, Defaults, Utils {
@@ -92,5 +92,12 @@ contract BaseTest is Assertions, Defaults, Utils {
         });
 
         mock_helper_order(params);
+    }
+
+    /// @dev Helper to mock price feed data for both feeds - decimals, latestRoundData
+    function setPriceFeedData(FeedParams memory params0, FeedParams memory params1) internal {
+        setFeedDecimals(params0.decimals, params1.decimals);
+        mock_feed_latestRoundData(params0.addr, params0.answer, params0.updatedAt);
+        mock_feed_latestRoundData(params1.addr, params1.answer, params1.updatedAt);
     }
 }

--- a/test/Base.t.sol
+++ b/test/Base.t.sol
@@ -4,15 +4,18 @@ pragma solidity >=0.8.25 < 0.9.0;
 import { ExposedLPOracle } from "test/harness/ExposedLPOracle.sol";
 import { MockBCoWHelper } from "test/mocks/MockBCoWHelper.sol";
 
-import { Utils } from "test/utils/Utils.sol";
+import { Assertions } from "test/utils/Assertions.sol";
 import { Defaults } from "test/utils/Defaults.sol";
 import { OrderParams, TokenParams } from "test/utils/Types.sol";
+import { Utils } from "test/utils/Utils.sol";
 
-contract BaseTest is Defaults, Utils {
+contract BaseTest is Assertions, Defaults, Utils {
     address internal MOCK_POOL = makeAddr("MOCK_POOL");
     address internal MOCK_FACTORY = makeAddr("MOCK_FACTORY");
     address internal TOKEN0 = makeAddr("TOKEN0");
     address internal TOKEN1 = makeAddr("TOKEN1");
+    address internal FEED0 = makeAddr("FEED0");
+    address internal FEED1 = makeAddr("FEED1");
 
     ExposedLPOracle internal oracle;
     MockBCoWHelper internal helper;
@@ -25,14 +28,35 @@ contract BaseTest is Defaults, Utils {
         helper = new MockBCoWHelper(MOCK_FACTORY);
         vm.label(address(helper), "MockBCoWHelper");
 
-        // Setup default token configuration with 18 decimals
-        setTokenDecimals(18, 18);
+        // Setup default decimal configs: feeds -> 8, tokens -> 18
+        setAllAddressDecimals(8, 8, 18, 18);
 
         // Initialize oracle with default configuration
-        oracle = new ExposedLPOracle(MOCK_POOL, address(helper));
+        oracle = new ExposedLPOracle(MOCK_POOL, address(helper), FEED0, FEED1);
         vm.label(address(oracle), "ExposedLPOracle");
     }
 
+    /// @dev Helper to mock all decimals for addresses in LPOracle.
+    /// @dev Inputs in order they appear in the constructor.
+    function setAllAddressDecimals(
+        uint8 feedDecimals0,
+        uint8 feedDecimals1,
+        uint8 tokenDecimals0,
+        uint8 tokenDecimals1
+    )
+        internal
+    {
+        setFeedDecimals(feedDecimals0, feedDecimals1);
+        setTokenDecimals(tokenDecimals0, tokenDecimals1);
+    }
+
+    /// @dev Helper to mock price feed decimals
+    function setFeedDecimals(uint8 decimals0, uint8 decimals1) internal {
+        mock_address_decimals(FEED0, decimals0);
+        mock_address_decimals(FEED1, decimals1);
+    }
+
+    /// @dev Helper to mock BCoWHelper.tokens() call & set token decimals
     function setTokenDecimals(uint8 decimals0, uint8 decimals1) internal {
         // Mock helper.tokens() call
         mock_helper_tokens(address(helper), MOCK_POOL, TOKEN0, TOKEN1);
@@ -42,12 +66,13 @@ contract BaseTest is Defaults, Utils {
         mock_address_decimals(TOKEN1, decimals1);
     }
 
-    // Helper to reinitialize oracle after changing decimals
+    /// @dev Helper to reinitialize oracle after changing decimals
     function reinitOracle(uint8 decimals0, uint8 decimals1) internal {
-        setTokenDecimals(decimals0, decimals1);
-        oracle = new ExposedLPOracle(MOCK_POOL, address(helper));
+        setAllAddressDecimals(8, 8, decimals0, decimals1);
+        oracle = new ExposedLPOracle(MOCK_POOL, address(helper), FEED0, FEED1);
     }
 
+    // Todo: implement input args for pool. tokens, balances, etc.
     function setMockOrder() internal {
         OrderParams memory params = OrderParams({
             pool: MOCK_POOL,

--- a/test/harness/ExposedLPOracle.sol
+++ b/test/harness/ExposedLPOracle.sol
@@ -5,7 +5,14 @@ import { LPOracle } from "src/LPOracle.sol";
 import { GPv2Order } from "cowprotocol/contracts/libraries/GPv2Order.sol";
 
 contract ExposedLPOracle is LPOracle {
-    constructor(address _pool, address _helper) LPOracle(_pool, _helper) { }
+    constructor(
+        address _pool,
+        address _helper,
+        address _feed0,
+        address _feed1
+    )
+        LPOracle(_pool, _helper, _feed0, _feed1)
+    { }
 
     function exposed_simulateOrder(uint256 price0, uint256 price1) external view returns (GPv2Order.Data memory) {
         return _simulateOrder(price0, price1);

--- a/test/harness/ExposedLPOracle.sol
+++ b/test/harness/ExposedLPOracle.sol
@@ -14,6 +14,10 @@ contract ExposedLPOracle is LPOracle {
         LPOracle(_pool, _helper, _feed0, _feed1)
     { }
 
+    function exposed__getFeedData() external view returns (uint256 price0, uint256 price1, uint256 updatedAt) {
+        return _getFeedData();
+    }
+
     function exposed_simulateOrder(uint256 price0, uint256 price1) external view returns (GPv2Order.Data memory) {
         return _simulateOrder(price0, price1);
     }

--- a/test/unit/AdjustDecimals.t.sol
+++ b/test/unit/AdjustDecimals.t.sol
@@ -79,8 +79,8 @@ contract AdjustDecimals_Unit_Test is BaseTest {
         view
     {
         // Bound decimals to valid ranges
-        decimals0 = uint8(bound(decimals0, 0, 18));
-        decimals1 = uint8(bound(decimals1, 0, 18));
+        decimals0 = boundUint8(decimals0, 0, 18);
+        decimals1 = boundUint8(decimals1, 0, 18);
 
         // Bound values to prevent overflow
         value0 = bound(value0, 0, type(uint256).max / (10 ** 18));

--- a/test/unit/Constructor.t.sol
+++ b/test/unit/Constructor.t.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.25;
+
+import { BaseTest } from "test/Base.t.sol";
+import { LPOracle } from "src/LPOracle.sol";
+
+contract Constructor_Unit_Test is BaseTest {
+    function test_ShouldRevert_Feed0Decimals_Gt18() external {
+        setFeedDecimals(19, 8);
+
+        vm.expectRevert(LPOracle.UnsupportedDecimals.selector);
+        new LPOracle(MOCK_POOL, address(helper), FEED0, FEED1);
+    }
+
+    function test_ShouldRevert_Feed1Decimals_Gt18() external {
+        setFeedDecimals(8, 19);
+
+        vm.expectRevert(LPOracle.UnsupportedDecimals.selector);
+        new LPOracle(MOCK_POOL, address(helper), FEED0, FEED1);
+    }
+
+    modifier whenDecimalsLtEq18() {
+        _;
+    }
+
+    function testFuzz_Constructor(
+        uint8 feed0Decimals,
+        uint8 feed1Decimals,
+        uint8 token0Decimals,
+        uint8 token1Decimals
+    )
+        external
+        whenDecimalsLtEq18
+    {
+        feed0Decimals = boundUint8(feed0Decimals, 0, 18);
+        feed1Decimals = boundUint8(feed1Decimals, 0, 18);
+        token0Decimals = boundUint8(token0Decimals, 0, 18);
+        token1Decimals = boundUint8(token1Decimals, 0, 18);
+
+        setAllAddressDecimals(feed0Decimals, feed1Decimals, token0Decimals, token1Decimals);
+        LPOracle oracle_ = new LPOracle(MOCK_POOL, address(helper), FEED0, FEED1);
+
+        assertEq(oracle_.POOL(), MOCK_POOL, "POOL");
+        assertEq(oracle_.HELPER(), helper, "HELPER");
+        assertEq(address(oracle_.TOKEN0()), TOKEN0, "TOKEN0");
+        assertEq(address(oracle_.TOKEN1()), TOKEN1, "TOKEN1");
+        assertEq(oracle_.TOKEN0_DECIMALS(), token0Decimals, "TOKEN0_DECIMALS");
+        assertEq(oracle_.TOKEN1_DECIMALS(), token1Decimals, "TOKEN1_DECIMALS");
+        assertEq(address(oracle_.FEED0()), FEED0, "FEED0");
+        assertEq(address(oracle_.FEED1()), FEED1, "FEED1");
+    }
+}

--- a/test/unit/GetFeedData.t.sol
+++ b/test/unit/GetFeedData.t.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.25;
+
+import { BaseTest } from "test/Base.t.sol";
+import { FeedParams } from "test/utils/Types.sol";
+
+contract GetFeedData_Unit_Test is BaseTest {
+    function testFuzz_Feed0_UpdatedAt_IsOldest(uint256 feed0UpdatedAt, uint256 feed1UpdatedAt) external {
+        feed0UpdatedAt = bound(feed0UpdatedAt, 0, DEC_1_2024);
+        feed1UpdatedAt = bound(feed1UpdatedAt, feed0UpdatedAt + 1, type(uint40).max);
+
+        FeedParams memory params0 = FeedParams({ addr: FEED0, decimals: 8, answer: 1e8, updatedAt: feed0UpdatedAt });
+        FeedParams memory params1 = FeedParams({ addr: FEED1, decimals: 8, answer: 1.1e8, updatedAt: feed1UpdatedAt });
+
+        setPriceFeedData(params0, params1);
+
+        (,, uint256 updatedAt) = oracle.exposed__getFeedData();
+
+        assertEq(updatedAt, feed0UpdatedAt, "updatedAt");
+    }
+
+    function testFuzz_Feed1_UpdatedAt_IsOldest(uint256 feed0UpdatedAt, uint256 feed1UpdatedAt) external {
+        feed1UpdatedAt = bound(feed1UpdatedAt, 0, DEC_1_2024);
+        feed0UpdatedAt = bound(feed0UpdatedAt, feed1UpdatedAt + 1, type(uint40).max);
+
+        FeedParams memory params0 = FeedParams({ addr: FEED0, decimals: 8, answer: 1e8, updatedAt: feed0UpdatedAt });
+        FeedParams memory params1 = FeedParams({ addr: FEED1, decimals: 8, answer: 1.1e8, updatedAt: feed1UpdatedAt });
+
+        setPriceFeedData(params0, params1);
+
+        (,, uint256 updatedAt) = oracle.exposed__getFeedData();
+
+        assertEq(updatedAt, feed1UpdatedAt, "updatedAt");
+    }
+
+    modifier whenSameDecimals() {
+        _;
+    }
+
+    modifier whenSameUpdatedAt() {
+        _;
+    }
+
+    /// @dev When negative answers, explicit casting leads to unexpected behaviour.
+    /// @dev In consuming functions, verify this can't lead to potentially harmful price values.
+    function testFuzz_NegativeAnswer0(int256 answer0, int256 answer1) external whenSameDecimals whenSameUpdatedAt {
+        vm.assume(answer0 < 0);
+        answer1 = bound(answer1, 1, 1e16);
+
+        FeedParams memory params0 =
+            FeedParams({ addr: FEED0, decimals: 8, answer: answer0, updatedAt: block.timestamp });
+        FeedParams memory params1 =
+            FeedParams({ addr: FEED1, decimals: 8, answer: answer1, updatedAt: block.timestamp });
+
+        setPriceFeedData(params0, params1);
+
+        (uint256 price0, uint256 price1, uint256 updatedAt) = oracle.exposed__getFeedData();
+
+        assertGt(price0, type(uint128).max, "price0 > MAX_UINT128");
+        assertEq(price1, uint256(answer1), "price1 == uint256(answer1)");
+        assertEq(updatedAt, block.timestamp, "updatedAt");
+    }
+
+    /// @dev When negative answers, explicit casting leads to unexpected behaviour.
+    function testFuzz_NegativeAnswer1(int256 answer0, int256 answer1) external whenSameDecimals whenSameUpdatedAt {
+        vm.assume(answer1 < 0);
+        answer0 = bound(answer0, 1, 1e16);
+
+        FeedParams memory params0 =
+            FeedParams({ addr: FEED0, decimals: 8, answer: answer0, updatedAt: block.timestamp });
+        FeedParams memory params1 =
+            FeedParams({ addr: FEED1, decimals: 8, answer: answer1, updatedAt: block.timestamp + 1 });
+
+        setPriceFeedData(params0, params1);
+
+        (uint256 price0, uint256 price1, uint256 updatedAt) = oracle.exposed__getFeedData();
+
+        assertGt(price1, type(uint128).max, "price1 > MAX_UINT128");
+        assertEq(price0, uint256(answer0), "price0 == uint256(answer0)");
+        assertEq(updatedAt, block.timestamp, "updatedAt");
+    }
+
+    modifier whenPositivePrices() {
+        _;
+    }
+
+    function testFuzz_getFeedData(int256 answer0, int256 answer1) external whenPositivePrices whenSameUpdatedAt {
+        answer0 = bound(answer0, 1, 1e24);
+        answer1 = bound(answer1, 1, 1e24);
+
+        FeedParams memory params0 =
+            FeedParams({ addr: FEED0, decimals: 8, answer: answer0, updatedAt: block.timestamp });
+        FeedParams memory params1 =
+            FeedParams({ addr: FEED1, decimals: 8, answer: answer1, updatedAt: block.timestamp + 1 });
+
+        setPriceFeedData(params0, params1);
+
+        (uint256 price0, uint256 price1, uint256 updatedAt) = oracle.exposed__getFeedData();
+
+        assertEq(int256(price0), answer0);
+    }
+}

--- a/test/utils/Assertions.sol
+++ b/test/utils/Assertions.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity >=0.8.25 < 0.9.0;
+
+import { StdAssertions } from "forge-std/Test.sol";
+import { ICOWAMMPoolHelper } from "@cow-amm/interfaces/ICOWAMMPoolHelper.sol";
+import { AggregatorV3Interface } from "@cow-amm/interfaces/AggregatorV3Interface.sol";
+import { IERC20 } from "cowprotocol/contracts/interfaces/IERC20.sol";
+
+contract Assertions is StdAssertions {
+    function assertEq(IERC20 a, IERC20 b) internal pure {
+        assertEq(address(a), address(b));
+    }
+
+    function assertEq(IERC20 a, IERC20 b, string memory err) internal pure {
+        assertEq(address(a), address(b), err);
+    }
+
+    function assertEq(ICOWAMMPoolHelper a, ICOWAMMPoolHelper b) internal pure {
+        assertEq(address(a), address(b));
+    }
+
+    function assertEq(ICOWAMMPoolHelper a, ICOWAMMPoolHelper b, string memory err) internal pure {
+        assertEq(address(a), address(b), err);
+    }
+
+    function assertEq(AggregatorV3Interface a, AggregatorV3Interface b) internal pure {
+        assertEq(address(a), address(b));
+    }
+
+    function assertEq(AggregatorV3Interface a, AggregatorV3Interface b, string memory err) internal pure {
+        assertEq(address(a), address(b), err);
+    }
+}

--- a/test/utils/Defaults.sol
+++ b/test/utils/Defaults.sol
@@ -7,4 +7,5 @@ contract Defaults {
     uint256 internal constant NORMALIZED_WEIGHT = 0.5e18;
     uint256 internal constant DENORMALIZED_WEIGHT = 1e18;
     bytes32 internal constant APP_DATA = keccak256("APP_DATA");
+    uint256 internal constant DEC_1_2024 = 1_733_011_200;
 }

--- a/test/utils/Types.sol
+++ b/test/utils/Types.sol
@@ -14,3 +14,10 @@ struct OrderParams {
     TokenParams token0;
     TokenParams token1;
 }
+
+struct FeedParams {
+    address addr;
+    uint8 decimals;
+    int256 answer;
+    uint256 updatedAt;
+}

--- a/test/utils/Utils.sol
+++ b/test/utils/Utils.sol
@@ -6,9 +6,19 @@ import { OrderParams } from "test/utils/Types.sol";
 
 contract Utils is Test {
     /*----------------------------------------------------------*|
+    |*  # BOUNDS                                                *|
+    |*----------------------------------------------------------*/
+
+    /// @dev Helper to bound uint8 values for fuzz testing.
+    function boundUint8(uint8 x, uint8 min, uint8 max) internal pure returns (uint8) {
+        return uint8(bound(x, min, max));
+    }
+
+    /*----------------------------------------------------------*|
     |*  # MOCK CALLS: SHARED                                    *|
     |*----------------------------------------------------------*/
 
+    /// @dev Helper to mock a `decimals()` call to an arbitrary address.
     function mock_address_decimals(address addr, uint8 decimals) internal {
         vm.mockCall(addr, abi.encodeWithSignature("decimals()"), abi.encode(decimals));
     }
@@ -17,6 +27,7 @@ contract Utils is Test {
     |*  # MOCK CALLS: ERC20                                     *|
     |*----------------------------------------------------------*/
 
+    /// @dev Helper to mock token pool balances.
     function mock_token_balanceOf(address token, address pool, uint256 balance) internal {
         vm.mockCall(token, abi.encodeWithSignature("balanceOf(address)", pool), abi.encode(balance));
     }
@@ -25,14 +36,17 @@ contract Utils is Test {
     |*  # MOCK CALLS: BCoWPool                                 *|
     |*----------------------------------------------------------*/
 
+    /// @dev Helper to mock the normalized weight of a pool token.
     function mock_pool_getNormalizedWeight(address pool, address token, uint256 normWeight) internal {
         vm.mockCall(pool, abi.encodeWithSignature("getNormalizedWeight(address)", token), abi.encode(normWeight));
     }
 
+    /// @dev Helper to mock the denormalized weight of a pool token.
     function mock_pool_getDenormalizedWeight(address pool, address token, uint256 denormWeight) internal {
         vm.mockCall(pool, abi.encodeWithSignature("getDenormalizedWeight(address)", token), abi.encode(denormWeight));
     }
 
+    /// @dev Helper to mock the `pool.getFinalTokens` call.
     function mock_pool_getFinalTokens(address pool, address token0, address token1) internal {
         address[] memory tokens = new address[](2);
         tokens[0] = token0;
@@ -41,6 +55,7 @@ contract Utils is Test {
         vm.mockCall(pool, abi.encodeWithSignature("getFinalTokens()"), abi.encode(tokens));
     }
 
+    /// @dev Helper to set the pool state as finalized, required for LPOracle._simulateOrder calls.
     function mock_pool__finalized(address pool) internal {
         vm.mockCall(pool, abi.encodeWithSignature("_finalized()"), abi.encode(true));
     }
@@ -48,6 +63,8 @@ contract Utils is Test {
     /*----------------------------------------------------------*|
     |*  # MOCK CALLS: BCoWHelper                                *|
     |*----------------------------------------------------------*/
+
+    /// @dev Helper to mock the tokens array in BCoWHelper.
     function mock_helper_tokens(address helper, address pool, address token0, address token1) internal {
         // Setup token addresses
         address[] memory tokens = new address[](2);
@@ -58,6 +75,7 @@ contract Utils is Test {
         vm.mockCall(helper, abi.encodeWithSignature("tokens(address)", pool), abi.encode(tokens));
     }
 
+    /// @dev Helper to mock the BCoWHelper._reserves call.
     function mock_helper_reserves(
         address pool,
         address token,
@@ -72,6 +90,7 @@ contract Utils is Test {
         mock_pool_getDenormalizedWeight(pool, token, denormWeight);
     }
 
+    /// @dev Helper to aggregate all mock calls requried for the BCoWHelper.order call in LPOracle._simulateOrder.
     function mock_helper_order(OrderParams memory params) internal {
         // Mock BCoWFactory.isBPool
         mock_factory_isBPool(params.factory, params.pool);
@@ -94,10 +113,12 @@ contract Utils is Test {
     |*  # MOCK CALLS: BCoWFactory                               *|
     |*----------------------------------------------------------*/
 
+    /// @dev Helper to mock the `APP_DATA` in the factory contract, required to deploy MockBCoWHelper.
     function mock_factory_APP_DATA(address factory, bytes32 data) internal {
         vm.mockCall(factory, abi.encodeWithSignature("APP_DATA()"), abi.encode(data));
     }
 
+    /// @dev Helper to mock the factory.isBPool call, required to mock the order.
     function mock_factory_isBPool(address factory, address pool) internal {
         vm.mockCall(factory, abi.encodeWithSignature("isBPool(address)", pool), abi.encode(true));
     }

--- a/test/utils/Utils.sol
+++ b/test/utils/Utils.sol
@@ -24,6 +24,14 @@ contract Utils is Test {
     }
 
     /*----------------------------------------------------------*|
+    |*  # MOCK CALLS: AggregatorV3Interface                     *|
+    |*----------------------------------------------------------*/
+
+    function mock_feed_latestRoundData(address feed, int256 answer, uint256 updatedAt) internal {
+        vm.mockCall(feed, abi.encodeWithSignature("latestRoundData()"), abi.encode(0, answer, 0, updatedAt, 0));
+    }
+
+    /*----------------------------------------------------------*|
     |*  # MOCK CALLS: ERC20                                     *|
     |*----------------------------------------------------------*/
 


### PR DESCRIPTION
# Chainlink Price Feed Integration

This PR adds the initial integration with Chainlink price feeds, including storage setup, validation, and data retrieval functionality.

## Key changes:
- Add storage variables for Chainlink price feeds with constructor initialization
- Implement decimal validation (revert if > 18 decimals)
- Add `_getFeedData` function for price feed data retrieval
- Enhance test suite with new utilities and constructor tests

## Discussion Points
Looking for feedback on the `_getFeedData` implementation, specifically:
1. Should we implement try/catch for more graceful error handling? See "Unhandled Oracle Revert Denial Of Service" section in reference below.
2. Would it be valuable to add a fallback oracle mechanism in case of feed failures?

Related: [Chainlink Oracle DeFi Attacks](https://medium.com/cyfrin/chainlink-oracle-defi-attacks-93b6cb6541bf#e100)

Note: PR is in draft while awaiting discussion on these points.