### PR TITLE
feat: Setup fork testing infrastructure

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -4,7 +4,7 @@
 auto_detect_solc = false
 block_timestamp = 1_680_220_800 # March 31, 2023 at 00:00 GMT
 bytecode_hash = "none"
-evm_version = "shanghai"
+evm_version = "cancun"
 fuzz = { runs = 1_000 }
 gas_reports = ["*"]
 optimizer = true

--- a/test/fork/Description.t.sol
+++ b/test/fork/Description.t.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity >=0.8.25 < 0.9.0;
+
+import { ForkTest } from "test/fork/Fork.t.sol";
+
+contract Description_Fork_Test is ForkTest {
+    constructor(address _token0, address _token1) ForkTest(_token0, _token1) { }
+
+    function test_Descriptor() external view {
+        string memory expectedDescription = string.concat(FORK_POOL.name(), " LP Token / USD");
+        assertEq(oracle.description(), expectedDescription, "description");
+    }
+}

--- a/test/fork/Fork.t.sol
+++ b/test/fork/Fork.t.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity >=0.8.25 < 0.9.0;
+
+import { Test } from "forge-std/Test.sol";
+import { Addresses } from "test/utils/Addresses.sol";
+import { Assertions } from "test/utils/Assertions.sol";
+
+import { LPOracle } from "src/LPOracle.sol";
+import { LPOracleFactory } from "src/LPOracleFactory.sol";
+
+import { ICOWAMMPoolHelper } from "@cow-amm/interfaces/ICOWAMMPoolHelper.sol";
+import { AggregatorV3Interface } from "@cow-amm/interfaces/AggregatorV3Interface.sol";
+import { IERC20 } from "cowprotocol/contracts/interfaces/IERC20.sol";
+
+contract ForkTest is Addresses, Assertions, Test {
+    LPOracle internal oracle;
+    LPOracleFactory internal factory;
+
+    ICOWAMMPoolHelper internal immutable FORK_HELPER;
+    IERC20 internal immutable FORK_POOL;
+    IERC20 internal immutable FORK_TOKEN0;
+    IERC20 internal immutable FORK_TOKEN1;
+    AggregatorV3Interface internal immutable FORK_FEED0;
+    AggregatorV3Interface internal immutable FORK_FEED1;
+
+    constructor(address _token0, address _token1) {
+        FORK_TOKEN0 = IERC20(_token0);
+        FORK_TOKEN1 = IERC20(_token1);
+
+        (address _pool, address _helper, address _feed0, address _feed1) = getOracleConstructorArgs(_token0, _token1);
+
+        FORK_POOL = IERC20(_pool);
+        FORK_HELPER = ICOWAMMPoolHelper(_helper);
+        FORK_FEED0 = AggregatorV3Interface(_feed0);
+        FORK_FEED1 = AggregatorV3Interface(_feed1);
+    }
+
+    function setUp() public virtual {
+        // Fork Ethereum Mainnet at a specific block number.
+        // Be careful with setting block numbers at times when the pool doesn't exist.
+        vm.createSelectFork({ blockNumber: 21_422_754, urlOrAlias: "mainnet" });
+
+        // Deploy contracts to the fork.
+        factory = new LPOracleFactory(address(FORK_HELPER));
+        oracle = LPOracle(factory.deployOracle(address(FORK_POOL), address(FORK_FEED0), address(FORK_FEED1)));
+
+        // Label contracts.
+        labelContracts();
+    }
+
+    function labelContracts() internal {
+        vm.label(address(factory), "FACTORY");
+        vm.label(address(oracle), "ORACLE");
+        vm.label(address(FORK_HELPER), "HELPER");
+        vm.label(address(FORK_POOL), "POOL");
+        vm.label(address(FORK_TOKEN0), "TOKEN0");
+        vm.label(address(FORK_TOKEN1), "TOKEN1");
+        vm.label(address(FORK_FEED0), "FEED0");
+        vm.label(address(FORK_FEED1), "FEED1");
+    }
+}

--- a/test/fork/pools/WETH50UNI50.t.sol
+++ b/test/fork/pools/WETH50UNI50.t.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity >=0.8.25 < 0.9.0;
+
+import { Description_Fork_Test } from "test/fork/Description.t.sol";
+import { Addresses } from "test/utils/Addresses.sol";
+
+contract WETH50UNI50_Description_Fork_Test is Description_Fork_Test(Addresses.WETH, Addresses.UNI) { }

--- a/test/utils/Addresses.sol
+++ b/test/utils/Addresses.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity >=0.8.25 < 0.9.0;
+
+/// @dev Helper contract to obtain price feeds and pools for eth mainnet contracts
+contract Addresses {
+    /// @dev Deployed BCoWHelper contract address.
+    address internal constant HELPER = 0x3FF0041A614A9E6Bf392cbB961C97DA214E9CB31;
+
+    /// @dev Token ids for retrieving deployed price feed and pool addresses.
+    address public constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+    address public constant UNI = 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984;
+    address public constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+    address public constant BAL = 0xba100000625a3754423978a60c9317c58a424e3D;
+    address public constant AAVE = 0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9;
+    address public constant MKR = 0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2;
+    address public constant EIGEN = 0xec53bF9167f50cDEB3Ae105f56099aaaB9061F83;
+
+    /// @dev Mapping token id to deployed price feed address.
+    mapping(address token => address feed) internal feeds;
+
+    /// @dev Mapping pool id to deployed pool address.
+    mapping(bytes32 id => address pool) internal pools;
+
+    constructor() {
+        /* Setup feeds  */
+        feeds[WETH] = 0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419;
+        feeds[UNI] = 0x553303d460EE0afB37EdFf9bE42922D8FF63220e;
+        feeds[USDC] = 0x8fFfFfd4AfB6115b954Bd326cbe7B4BA576818f6;
+        feeds[BAL] = 0xdF2917806E30300537aEB49A7663062F4d1F2b5F;
+        feeds[AAVE] = 0x547a514d5e3769680Ce22B2361c10Ea13619e8a9;
+        feeds[MKR] = 0xec1D1B3b0443256cc3860e24a46F108e699484Aa;
+        feeds[EIGEN] = 0xf2917e602C2dCa458937fad715bb1E465305A4A1;
+
+        /* Setup pools  */
+        pools[_getPoolId(WETH, UNI)] = 0xA81b22966f1841E383E69393175E2cc65F0a8854;
+        pools[_getPoolId(USDC, WETH)] = 0xf08D4dEa369C456d26a3168ff0024B904F2d8b91;
+        pools[_getPoolId(BAL, WETH)] = 0xf8F5B88328DFF3d19E5f4F11A9700293Ac8f638F;
+        pools[_getPoolId(AAVE, WETH)] = 0xf706c50513446d709f08d3e5126cd74fb6bFDA19;
+        pools[_getPoolId(MKR, WETH)] = 0x9fb7106c879FA48347796171982125a268ff0630;
+        pools[_getPoolId(WETH, EIGEN)] = 0xA62E2c047B65aeE3c3Ba7fC7C2BD95C82A514DE2;
+    }
+
+    /// @dev Use this function to obtain addresses for constructor args for deploying LPOracle on fork tests.
+    function getOracleConstructorArgs(
+        address token0,
+        address token1
+    )
+        internal
+        view
+        returns (address, address, address, address)
+    {
+        address pool = pools[_getPoolId(token0, token1)];
+        address feed0 = feeds[token0];
+        address feed1 = feeds[token1];
+        require(pool != address(0) && feed0 != address(0) && feed1 != address(0));
+        return (pool, HELPER, feed0, feed1);
+    }
+
+    function _getPoolId(address token0, address token1) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked(token0, token1));
+    }
+}


### PR DESCRIPTION
- Configure foundry.toml for Cancun EVM required by fork tests. Transient storage opcodes required.
- Add base fork test contract as template for pool tests.
- Create Addresses utility contract for chainlink/pool addresses.
- Add example fork test implementations:
  - Description contract showing base usage
  - WETH-UNI 50/50 pool test contract

This setup enables fork testing of pool oracle implementations against production pools and price feeds. Once implemented, we can start adding fork testing contracts.