### PR TITLE
[Easy] Delete Factory Interface

### DIFF
--- a/src/LPOracleFactory.sol
+++ b/src/LPOracleFactory.sol
@@ -3,16 +3,14 @@ pragma solidity 0.8.25;
 
 import { LPOracle } from "./LPOracle.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
-import { ILPOracleFactory } from "./interfaces/IOracleFactory.sol";
 
 /// @title LPOracle Factory
 /// @notice Factory contract for deploying LPOracle instances with deterministic addresses
-contract LPOracleFactory is Ownable, ILPOracleFactory {
+contract LPOracleFactory is Ownable {
     error OracleAlreadyExists();
     error DeployFailed();
 
     /// @notice BCoWHelper contract address used for all oracle deployments
-
     address public immutable HELPER;
 
     /// @notice Creation code hash for LPOracle contract

--- a/src/interfaces/IOracleFactory.sol
+++ b/src/interfaces/IOracleFactory.sol
@@ -1,8 +1,0 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.25;
-
-interface ILPOracleFactory {
-    function deployOracle(address pool, address feed0, address feed1) external returns (address oracle);
-    function computeOracleAddress(address pool, address feed0, address feed1) external view returns (address);
-    function getOracle(address pool) external view returns (address);
-}

--- a/test/unit/OracleFactory.t.sol
+++ b/test/unit/OracleFactory.t.sol
@@ -4,11 +4,10 @@ pragma solidity 0.8.25;
 import { BaseTest } from "test/Base.t.sol";
 import { console } from "forge-std/console.sol";
 import { LPOracleFactory } from "src/LPOracleFactory.sol";
-import { ILPOracleFactory } from "src/interfaces/IOracleFactory.sol";
 import { LPOracle } from "src/LPOracle.sol";
 
 contract OracleFactoryBenchmark is BaseTest {
-    ILPOracleFactory public factory;
+    LPOracleFactory public factory;
 
     function setUp() public override {
         // Call the setUp() function from BaseTest
@@ -26,7 +25,7 @@ contract OracleFactoryBenchmark is BaseTest {
         uint256 writes;
     }
 
-    function _benchmarkFactory(ILPOracleFactory _factory) private returns (BenchmarkResult memory) {
+    function _benchmarkFactory(LPOracleFactory _factory) private returns (BenchmarkResult memory) {
         vm.record();
         uint256 gasStart = gasleft();
         _factory.deployOracle(MOCK_POOL, FEED0, FEED1);


### PR DESCRIPTION
This factory was only needed for initial development when trying out 4 different Factory implementations and benchmarking them. Only one ever wound up in the main branch so this interface is no longer necessary.