### PR TITLE
test: refactor test suite and add utility contracts

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -3,6 +3,7 @@
 [profile.default]
 auto_detect_solc = false
 block_timestamp = 1_680_220_800 # March 31, 2023 at 00:00 GMT
+memory_limit = 128000000
 bytecode_hash = "none"
 evm_version = "cancun"
 fuzz = { runs = 1_000 }

--- a/test/Base.t.sol
+++ b/test/Base.t.sol
@@ -79,7 +79,6 @@ contract BaseTest is Assertions, Calculations, Utils {
         mock_address_decimals(mocks.token1, decimals1);
     }
 
-    // Todo: implement input args for pool. tokens, balances, etc.
     function setMockOrder(uint256 token0Balance, uint256 token1Balance, uint256 token0Weight) internal {
         OrderParams memory params = defaults.mockOrderParamsCustomValues(token0Balance, token1Balance, token0Weight);
         mock_helper_order(params);
@@ -90,5 +89,20 @@ contract BaseTest is Assertions, Calculations, Utils {
         setFeedDecimals(params0.decimals, params1.decimals);
         mock_feed_latestRoundData(params0.addr, params0.answer, params0.updatedAt);
         mock_feed_latestRoundData(params1.addr, params1.answer, params1.updatedAt);
+    }
+
+    function setLatestRoundDataMocks(
+        int256 answer0,
+        int256 answer1,
+        uint256 token0Balance,
+        uint256 token1Balance,
+        uint256 token0Weight
+    )
+        internal
+    {
+        (FeedParams memory feedParams0, FeedParams memory feedParams1) = defaults.mockFeedParams(answer0, answer1);
+        setPriceFeedData(feedParams0, feedParams1);
+        setMockOrder(token0Balance, token1Balance, token0Weight);
+        mock_pool_totalSupply(mocks.pool, defaults.LP_TOKEN_SUPPLY());
     }
 }

--- a/test/unit/Constructor.t.sol
+++ b/test/unit/Constructor.t.sol
@@ -9,14 +9,14 @@ contract Constructor_Unit_Test is BaseTest {
         setFeedDecimals(19, 8);
 
         vm.expectRevert(LPOracle.UnsupportedDecimals.selector);
-        new LPOracle(MOCK_POOL, address(helper), FEED0, FEED1);
+        new LPOracle(mocks.pool, address(helper), mocks.feed0, mocks.feed1);
     }
 
     function test_ShouldRevert_Feed1Decimals_Gt18() external {
         setFeedDecimals(8, 19);
 
         vm.expectRevert(LPOracle.UnsupportedDecimals.selector);
-        new LPOracle(MOCK_POOL, address(helper), FEED0, FEED1);
+        new LPOracle(mocks.pool, address(helper), mocks.feed0, mocks.feed1);
     }
 
     modifier whenDecimalsLtEq18() {
@@ -38,15 +38,15 @@ contract Constructor_Unit_Test is BaseTest {
         token1Decimals = boundUint8(token1Decimals, 0, 18);
 
         setAllAddressDecimals(feed0Decimals, feed1Decimals, token0Decimals, token1Decimals);
-        LPOracle oracle_ = new LPOracle(MOCK_POOL, address(helper), FEED0, FEED1);
+        LPOracle oracle_ = new LPOracle(mocks.pool, address(helper), mocks.feed0, mocks.feed1);
 
-        assertEq(oracle_.POOL(), MOCK_POOL, "POOL");
+        assertEq(oracle_.POOL(), mocks.pool, "POOL");
         assertEq(oracle_.HELPER(), helper, "HELPER");
-        assertEq(address(oracle_.TOKEN0()), TOKEN0, "TOKEN0");
-        assertEq(address(oracle_.TOKEN1()), TOKEN1, "TOKEN1");
+        assertEq(address(oracle_.TOKEN0()), mocks.token0, "TOKEN0");
+        assertEq(address(oracle_.TOKEN1()), mocks.token1, "TOKEN1");
         assertEq(oracle_.TOKEN0_DECIMALS(), token0Decimals, "TOKEN0_DECIMALS");
         assertEq(oracle_.TOKEN1_DECIMALS(), token1Decimals, "TOKEN1_DECIMALS");
-        assertEq(address(oracle_.FEED0()), FEED0, "FEED0");
-        assertEq(address(oracle_.FEED1()), FEED1, "FEED1");
+        assertEq(address(oracle_.FEED0()), mocks.feed0, "FEED0");
+        assertEq(address(oracle_.FEED1()), mocks.feed1, "FEED1");
     }
 }

--- a/test/unit/GetFeedData.t.sol
+++ b/test/unit/GetFeedData.t.sol
@@ -6,11 +6,13 @@ import { FeedParams } from "test/utils/Types.sol";
 
 contract GetFeedData_Unit_Test is BaseTest {
     function testFuzz_Feed0_UpdatedAt_IsOldest(uint256 feed0UpdatedAt, uint256 feed1UpdatedAt) external {
-        feed0UpdatedAt = bound(feed0UpdatedAt, 0, DEC_1_2024);
+        feed0UpdatedAt = bound(feed0UpdatedAt, 0, defaults.DEC_1_2024());
         feed1UpdatedAt = bound(feed1UpdatedAt, feed0UpdatedAt + 1, type(uint40).max);
 
-        FeedParams memory params0 = FeedParams({ addr: FEED0, decimals: 8, answer: 1e8, updatedAt: feed0UpdatedAt });
-        FeedParams memory params1 = FeedParams({ addr: FEED1, decimals: 8, answer: 1.1e8, updatedAt: feed1UpdatedAt });
+        FeedParams memory params0 =
+            FeedParams({ addr: mocks.feed0, decimals: 8, answer: 1e8, updatedAt: feed0UpdatedAt });
+        FeedParams memory params1 =
+            FeedParams({ addr: mocks.feed1, decimals: 8, answer: 1.1e8, updatedAt: feed1UpdatedAt });
 
         setPriceFeedData(params0, params1);
 
@@ -20,11 +22,13 @@ contract GetFeedData_Unit_Test is BaseTest {
     }
 
     function testFuzz_Feed1_UpdatedAt_IsOldest(uint256 feed0UpdatedAt, uint256 feed1UpdatedAt) external {
-        feed1UpdatedAt = bound(feed1UpdatedAt, 0, DEC_1_2024);
+        feed1UpdatedAt = bound(feed1UpdatedAt, 0, defaults.DEC_1_2024());
         feed0UpdatedAt = bound(feed0UpdatedAt, feed1UpdatedAt + 1, type(uint40).max);
 
-        FeedParams memory params0 = FeedParams({ addr: FEED0, decimals: 8, answer: 1e8, updatedAt: feed0UpdatedAt });
-        FeedParams memory params1 = FeedParams({ addr: FEED1, decimals: 8, answer: 1.1e8, updatedAt: feed1UpdatedAt });
+        FeedParams memory params0 =
+            FeedParams({ addr: mocks.feed0, decimals: 8, answer: 1e8, updatedAt: feed0UpdatedAt });
+        FeedParams memory params1 =
+            FeedParams({ addr: mocks.feed1, decimals: 8, answer: 1.1e8, updatedAt: feed1UpdatedAt });
 
         setPriceFeedData(params0, params1);
 
@@ -47,10 +51,7 @@ contract GetFeedData_Unit_Test is BaseTest {
         vm.assume(answer0 < 0);
         answer1 = bound(answer1, 1, 1e16);
 
-        FeedParams memory params0 =
-            FeedParams({ addr: FEED0, decimals: 8, answer: answer0, updatedAt: block.timestamp });
-        FeedParams memory params1 =
-            FeedParams({ addr: FEED1, decimals: 8, answer: answer1, updatedAt: block.timestamp });
+        (FeedParams memory params0, FeedParams memory params1) = defaults.mockFeedParams(answer0, answer1);
 
         setPriceFeedData(params0, params1);
 
@@ -66,10 +67,7 @@ contract GetFeedData_Unit_Test is BaseTest {
         vm.assume(answer1 < 0);
         answer0 = bound(answer0, 1, 1e16);
 
-        FeedParams memory params0 =
-            FeedParams({ addr: FEED0, decimals: 8, answer: answer0, updatedAt: block.timestamp });
-        FeedParams memory params1 =
-            FeedParams({ addr: FEED1, decimals: 8, answer: answer1, updatedAt: block.timestamp });
+        (FeedParams memory params0, FeedParams memory params1) = defaults.mockFeedParams(answer0, answer1);
 
         setPriceFeedData(params0, params1);
 
@@ -88,10 +86,7 @@ contract GetFeedData_Unit_Test is BaseTest {
         answer0 = bound(answer0, 1, 1e24);
         answer1 = bound(answer1, 1, 1e24);
 
-        FeedParams memory params0 =
-            FeedParams({ addr: FEED0, decimals: 8, answer: answer0, updatedAt: block.timestamp });
-        FeedParams memory params1 =
-            FeedParams({ addr: FEED1, decimals: 8, answer: answer1, updatedAt: block.timestamp });
+        (FeedParams memory params0, FeedParams memory params1) = defaults.mockFeedParams(answer0, answer1);
 
         setPriceFeedData(params0, params1);
 

--- a/test/unit/LatestRoundData.t.sol
+++ b/test/unit/LatestRoundData.t.sol
@@ -3,20 +3,15 @@ pragma solidity 0.8.25;
 
 import { BaseTest } from "test/Base.t.sol";
 import { FeedParams } from "test/utils/Types.sol";
+import { IERC20 } from "cowprotocol/contracts/interfaces/IERC20.sol";
 
 contract LatestRoundData_Unit_Test is BaseTest {
-    // Default prices for this test suite
-    int256 internal constant ANSWER0 = 4000e8;
-    int256 internal constant ANSWER1 = 1e8;
-
     function testFuzz_shouldRevert_LtEqZeroAnswer0(int256 answer0) external {
         vm.assume(answer0 < 0);
 
-        (FeedParams memory feedParams0, FeedParams memory feedParams1) = defaults.mockFeedParams(answer0, 1e8);
-
-        setPriceFeedData(feedParams0, feedParams1);
-        setMockOrder(1e18, 1e18, defaults.WEIGHT_50());
-        mock_pool_totalSupply(mocks.pool, defaults.LP_TOKEN_SUPPLY());
+        setLatestRoundDataMocks(
+            answer0, defaults.ANSWER1(), defaults.TOKEN0_BALANCE(), defaults.TOKEN1_BALANCE(), defaults.WEIGHT_50()
+        );
 
         vm.expectRevert();
         oracle.latestRoundData();
@@ -25,11 +20,9 @@ contract LatestRoundData_Unit_Test is BaseTest {
     function testFuzz_shouldRevert_LtEqZeroAnswer1(int256 answer1) external {
         vm.assume(answer1 < 0);
 
-        (FeedParams memory feedParams0, FeedParams memory feedParams1) = defaults.mockFeedParams(1e8, answer1);
-
-        setPriceFeedData(feedParams0, feedParams1);
-        setMockOrder(1e18, 1e18, defaults.WEIGHT_50());
-        mock_pool_totalSupply(mocks.pool, defaults.LP_TOKEN_SUPPLY());
+        setLatestRoundDataMocks(
+            defaults.ANSWER0(), answer1, defaults.TOKEN0_BALANCE(), defaults.TOKEN1_BALANCE(), defaults.WEIGHT_50()
+        );
 
         vm.expectRevert();
         oracle.latestRoundData();
@@ -44,14 +37,12 @@ contract LatestRoundData_Unit_Test is BaseTest {
     }
 
     function test_50_50Pool() external whenPositivePrices whenBalancedPool {
-        (FeedParams memory feedParams0, FeedParams memory feedParams1) = defaults.mockFeedParams(ANSWER0, ANSWER1);
-        setPriceFeedData(feedParams0, feedParams1);
-
         uint256 token0PoolReserve = 1e18;
         uint256 token1PoolReserve = 4000e18;
-        setMockOrder(token0PoolReserve, token1PoolReserve, defaults.WEIGHT_50());
 
-        mock_pool_totalSupply(mocks.pool, defaults.LP_TOKEN_SUPPLY());
+        setLatestRoundDataMocks(
+            defaults.ANSWER0(), defaults.ANSWER1(), token0PoolReserve, token1PoolReserve, defaults.WEIGHT_50()
+        );
 
         (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) =
             oracle.latestRoundData();
@@ -68,14 +59,12 @@ contract LatestRoundData_Unit_Test is BaseTest {
     }
 
     function test_80_20Pool() external whenPositivePrices whenBalancedPool {
-        (FeedParams memory feedParams0, FeedParams memory feedParams1) = defaults.mockFeedParams(ANSWER0, ANSWER1);
-        setPriceFeedData(feedParams0, feedParams1);
-
         uint256 token0PoolReserve = 1e18;
         uint256 token1PoolReserve = 1000e18;
-        setMockOrder(token0PoolReserve, token1PoolReserve, defaults.WEIGHT_80());
 
-        mock_pool_totalSupply(mocks.pool, defaults.LP_TOKEN_SUPPLY());
+        setLatestRoundDataMocks(
+            defaults.ANSWER0(), defaults.ANSWER1(), token0PoolReserve, token1PoolReserve, defaults.WEIGHT_50()
+        );
 
         (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) =
             oracle.latestRoundData();
@@ -95,27 +84,24 @@ contract LatestRoundData_Unit_Test is BaseTest {
         _;
     }
 
-    function test_50_50Pool_LargeUnbalancing_TooMuchToken0() external whenPositivePrices whenUnbalancedPool {
-        (FeedParams memory feedParams0, FeedParams memory feedParams1) = defaults.mockFeedParams(ANSWER0, ANSWER1);
-
+    function test_50_50Pool_LargeUnbalancing_TooMuchToken1() external whenPositivePrices whenUnbalancedPool {
         // Initial balanced pool state
         uint256 token0PoolReserve = 1e18;
         uint256 token1PoolReserve = 4000e18;
 
+        setLatestRoundDataMocks(
+            defaults.ANSWER0(), defaults.ANSWER1(), token0PoolReserve, token1PoolReserve, defaults.WEIGHT_50()
+        );
+
         // Next pool state: attacker unbalances the pool
         // Assume: zero swap fees. Out token is token0.
         // tokenAmountOut is set to the maximum amount before reverting due to: BNum_BPowBaseTooHigh()
-        uint256 tokenAmountOut = 0.5e18 - 1 wei;
+        uint256 tokenAmountOut = maxAmountOutGivenBalanceOut(token0PoolReserve);
         uint256 tokenAmountIn = calcInGivenOut(
             token1PoolReserve, defaults.WEIGHT_50(), token0PoolReserve, defaults.WEIGHT_50(), tokenAmountOut, 0
         );
         token0PoolReserve -= tokenAmountOut;
         token1PoolReserve += tokenAmountIn;
-
-        // Mock calls
-        setPriceFeedData(feedParams0, feedParams1);
-        setMockOrder(token0PoolReserve, token1PoolReserve, defaults.WEIGHT_50());
-        mock_pool_totalSupply(mocks.pool, defaults.LP_TOKEN_SUPPLY());
 
         // Naive price
         // token0PoolReserve ≈ 0.5e8 token 0, token1PoolReserve ≈ 8000e18 token 1
@@ -132,27 +118,24 @@ contract LatestRoundData_Unit_Test is BaseTest {
         assertApproxEqRel(uint256(answer), 8e8, 2.5e16);
     }
 
-    function test_50_50Pool_LargeUnbalancing_TooMuchToken1() external whenPositivePrices whenUnbalancedPool {
-        (FeedParams memory feedParams0, FeedParams memory feedParams1) = defaults.mockFeedParams(ANSWER0, ANSWER1);
-
+    function test_50_50Pool_LargeUnbalancing_TooMuchToken0() external whenPositivePrices whenUnbalancedPool {
         // Initial balanced pool state
         uint256 token0PoolReserve = 1e18;
         uint256 token1PoolReserve = 4000e18;
 
+        setLatestRoundDataMocks(
+            defaults.ANSWER0(), defaults.ANSWER1(), token0PoolReserve, token1PoolReserve, defaults.WEIGHT_50()
+        );
+
         // Next pool state: attacker unbalances the pool
         // Assume: zero swap fees. Out token is token1.
         // tokenAmountOut is set to the maximum amount before reverting due to: BNum_BPowBaseTooHigh()
-        uint256 tokenAmountOut = 1999e18;
+        uint256 tokenAmountOut = maxAmountOutGivenBalanceOut(token1PoolReserve);
         uint256 tokenAmountIn = calcInGivenOut(
             token0PoolReserve, defaults.WEIGHT_50(), token1PoolReserve, defaults.WEIGHT_50(), tokenAmountOut, 0
         );
         token1PoolReserve -= tokenAmountOut;
         token0PoolReserve += tokenAmountIn;
-
-        // Mock calls
-        setPriceFeedData(feedParams0, feedParams1);
-        setMockOrder(token0PoolReserve, token1PoolReserve, defaults.WEIGHT_50());
-        mock_pool_totalSupply(mocks.pool, defaults.LP_TOKEN_SUPPLY());
 
         // Naive price
         // token0PoolReserve ≈ 0.5e8 token 0, token1PoolReserve ≈ 8000e18 token 1
@@ -169,23 +152,21 @@ contract LatestRoundData_Unit_Test is BaseTest {
         assertApproxEqRel(uint256(answer), 8e8, 2.5e16);
     }
 
-    function test_80_20Pool_LargeUnbalancing_TooMuchToken0() external whenPositivePrices whenUnbalancedPool {
-        (FeedParams memory feedParams0, FeedParams memory feedParams1) = defaults.mockFeedParams(ANSWER0, ANSWER1);
-
+    function test_80_20Pool_LargeUnbalancing_TooMuchToken1() external whenPositivePrices whenUnbalancedPool {
         // Initial balanced pool state 80% token 0 - 20% token 1
         // Price in balanced state is 5e8
         uint256 token0PoolReserve = 1e18;
         uint256 token1PoolReserve = 1000e18;
 
-        // Mock calls
-        setPriceFeedData(feedParams0, feedParams1);
-        setMockOrder(token0PoolReserve, token1PoolReserve, defaults.WEIGHT_80()); // 3rd input is token0 weight
-        mock_pool_totalSupply(mocks.pool, defaults.LP_TOKEN_SUPPLY());
+        setLatestRoundDataMocks(
+            defaults.ANSWER0(), defaults.ANSWER1(), token0PoolReserve, token1PoolReserve, defaults.WEIGHT_80()
+        );
 
         // Next pool state: attacker unbalances the pool
         // Assume: zero swap fees. Out token is token0.
         // tokenAmountOut is set to approx. max amount before reverting due to: BNum_BPowBaseTooHigh()
-        uint256 tokenAmountOut = 0.5e18 - 1 wei;
+        // uint256 tokenAmountOut = 0.5e18 - 1 wei;
+        uint256 tokenAmountOut = maxAmountOutGivenBalanceOut(token0PoolReserve);
         uint256 tokenAmountIn = calcInGivenOut(
             token1PoolReserve, defaults.WEIGHT_20(), token0PoolReserve, defaults.WEIGHT_80(), tokenAmountOut, 0
         );
@@ -193,7 +174,7 @@ contract LatestRoundData_Unit_Test is BaseTest {
         token1PoolReserve += tokenAmountIn;
 
         // NaivePrice ≈ 18e8 == (0.5 * 4000 + 16000 * 1)
-        uint256 naivePrice = (token0PoolReserve * 4000e8 + token1PoolReserve * 1e8) / defaults.LP_TOKEN_SUPPLY();
+        uint256 naivePrice = (token0PoolReserve * 4000e8 + token1PoolReserve * 1e8) / IERC20(mocks.pool).totalSupply();
 
         // LP price
         (, int256 answer,,,) = oracle.latestRoundData();
@@ -205,41 +186,31 @@ contract LatestRoundData_Unit_Test is BaseTest {
         assertApproxEqRel(uint256(answer), 5e8, 1e15);
     }
 
-    // @todo @lumoswiz this test is failing due to OutOfGas. Revist after test refactor.
-    //    function test_80_20Pool_LargeUnbalancing_TooMuchToken1() external whenPositivePrices whenUnbalancedPool {
-    //        (FeedParams memory feedParams0, FeedParams memory feedParams1) = defaults.mockFeedParams(ANSWER0,
-    // ANSWER1);
-    //
-    //        // Initial balanced pool state 80% token 0 - 20% token 1
-    //        // Price in balanced state is 5e8
-    //        uint256 token0PoolReserve = 1e18;
-    //        uint256 token1PoolReserve = 1000e18;
-    //
-    //        // Mock calls
-    //        setPriceFeedData(feedParams0, feedParams1);
-    //        setMockOrder(token0PoolReserve, token1PoolReserve, defaults.WEIGHT_80()); // 3rd input is token0 weight
-    //        mock_pool_totalSupply(mocks.pool, defaults.LP_TOKEN_SUPPLY());
-    //
-    //        // Next pool state: attacker unbalances the pool
-    //        // Assume: zero swap fees. Out token is token1.
-    //        // tokenAmountOut is set to approx. max amount before reverting due to: BNum_BPowBaseTooHigh()
-    //        uint256 tokenAmountOut = 499_999_999_999_999_999_749;
-    //        uint256 tokenAmountIn = calcInGivenOut(
-    //            token0PoolReserve, defaults.WEIGHT_80(), token1PoolReserve, defaults.WEIGHT_20(), tokenAmountOut, 0
-    //        );
-    //        token1PoolReserve -= tokenAmountOut;
-    //        token0PoolReserve += tokenAmountIn;
-    //
-    //        // NaivePrice ≈ 10e8 == (0.5 * 4000 + 16000 * 1)
-    //        uint256 naivePrice = (token0PoolReserve * 4000e8 + token1PoolReserve * 1e8) / defaults.LP_TOKEN_SUPPLY();
-    //
-    //        // LP price
-    //        (, int256 answer,,,) = oracle.latestRoundData();
-    //
-    //        // Assertions
-    //        // The naive LP token price is approx 6% higher than balanced pool price.
-    //        assertApproxEqRel(naivePrice, 5e8, 6e16);
-    //        // LP token price is within 0.1% of the balance pool price.
-    //        assertApproxEqRel(uint256(answer), 5e8, 1e15);
-    //    }
+    function test_80_20Pool_LargeUnbalancing_TooMuchToken0() external whenPositivePrices whenUnbalancedPool {
+        // Initial balanced pool state 80% token 0 - 20% token 1
+        // Price in balanced state is 5e8
+        uint256 token0PoolReserve = 1e18;
+        uint256 token1PoolReserve = 1000e18;
+
+        setLatestRoundDataMocks(
+            defaults.ANSWER0(), defaults.ANSWER1(), token0PoolReserve, token1PoolReserve, defaults.WEIGHT_80()
+        );
+
+        uint256 tokenAmountOut = maxAmountOutGivenBalanceOut(1000e18);
+        uint256 tokenAmountIn = calcInGivenOut(1e18, 0.8e18, 1000e18, 0.2e18, tokenAmountOut, 0);
+        token1PoolReserve -= tokenAmountOut;
+        token0PoolReserve += tokenAmountIn;
+
+        // NaivePrice ≈ 18e8 == (0.5 * 4000 + 16000 * 1)
+        uint256 naivePrice = (token0PoolReserve * 4000e8 + token1PoolReserve * 1e8) / IERC20(mocks.pool).totalSupply();
+
+        // LP price
+        (, int256 answer,,,) = oracle.latestRoundData();
+
+        // Assertions
+        // The naive LP token price is within 6% of the balanced pool price.
+        assertApproxEqRel(naivePrice, 5e8, 6e16); // 1% diff
+        // LP token price is within 0.1% of the balance pool price.
+        assertApproxEqRel(uint256(answer), 5e8, 1e15);
+    }
 }

--- a/test/unit/LatestRoundData.t.sol
+++ b/test/unit/LatestRoundData.t.sol
@@ -113,9 +113,9 @@ contract LatestRoundData_Unit_Test is BaseTest {
 
         // Assertions
         // The naive LP token price is approx 25% higher than balanced pool price.
-        assertApproxEqRel(naivePrice, 10e8, 1e16);
-        // LP token price is within 2.5% of the balanced pool state
-        assertApproxEqRel(uint256(answer), 8e8, 2.5e16);
+        assertApproxEqRel(naivePrice, 10e8, 1e16); // within 1% of 10e8
+        // LP token price is within 0.1% of the balanced pool state
+        assertApproxEqRel(uint256(answer), 8e8, 1e15);
     }
 
     function test_LargeUnbalancing_50_50Pool_TooMuchToken0() external whenPositivePrices whenUnbalancedPool {
@@ -148,8 +148,8 @@ contract LatestRoundData_Unit_Test is BaseTest {
         // Assertions
         // The naive LP token price is approx 25% higher than balanced pool price.
         assertApproxEqRel(naivePrice, 10e8, 1e16);
-        // LP token price is within 2.5% of the balanced pool state
-        assertApproxEqRel(uint256(answer), 8e8, 2.5e16);
+        // LP token price is within 0.1% of the balanced pool state
+        assertApproxEqRel(uint256(answer), 8e8, 1e15);
     }
 
     function test_LargeUnbalancing_80_20Pool_TooMuchToken1() external whenPositivePrices whenUnbalancedPool {

--- a/test/unit/LatestRoundData.t.sol
+++ b/test/unit/LatestRoundData.t.sol
@@ -63,7 +63,7 @@ contract LatestRoundData_Unit_Test is BaseTest {
         uint256 token1PoolReserve = 1000e18;
 
         setLatestRoundDataMocks(
-            defaults.ANSWER0(), defaults.ANSWER1(), token0PoolReserve, token1PoolReserve, defaults.WEIGHT_50()
+            defaults.ANSWER0(), defaults.ANSWER1(), token0PoolReserve, token1PoolReserve, defaults.WEIGHT_80()
         );
 
         (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) =
@@ -84,7 +84,7 @@ contract LatestRoundData_Unit_Test is BaseTest {
         _;
     }
 
-    function test_50_50Pool_LargeUnbalancing_TooMuchToken1() external whenPositivePrices whenUnbalancedPool {
+    function test_LargeUnbalancing_50_50Pool_TooMuchToken1() external whenPositivePrices whenUnbalancedPool {
         // Initial balanced pool state
         uint256 token0PoolReserve = 1e18;
         uint256 token1PoolReserve = 4000e18;
@@ -118,7 +118,7 @@ contract LatestRoundData_Unit_Test is BaseTest {
         assertApproxEqRel(uint256(answer), 8e8, 2.5e16);
     }
 
-    function test_50_50Pool_LargeUnbalancing_TooMuchToken0() external whenPositivePrices whenUnbalancedPool {
+    function test_LargeUnbalancing_50_50Pool_TooMuchToken0() external whenPositivePrices whenUnbalancedPool {
         // Initial balanced pool state
         uint256 token0PoolReserve = 1e18;
         uint256 token1PoolReserve = 4000e18;
@@ -152,7 +152,7 @@ contract LatestRoundData_Unit_Test is BaseTest {
         assertApproxEqRel(uint256(answer), 8e8, 2.5e16);
     }
 
-    function test_80_20Pool_LargeUnbalancing_TooMuchToken1() external whenPositivePrices whenUnbalancedPool {
+    function test_LargeUnbalancing_80_20Pool_TooMuchToken1() external whenPositivePrices whenUnbalancedPool {
         // Initial balanced pool state 80% token 0 - 20% token 1
         // Price in balanced state is 5e8
         uint256 token0PoolReserve = 1e18;
@@ -186,7 +186,7 @@ contract LatestRoundData_Unit_Test is BaseTest {
         assertApproxEqRel(uint256(answer), 5e8, 1e15);
     }
 
-    function test_80_20Pool_LargeUnbalancing_TooMuchToken0() external whenPositivePrices whenUnbalancedPool {
+    function test_LargeUnbalancing_0_20Pool_TooMuchToken0() external whenPositivePrices whenUnbalancedPool {
         // Initial balanced pool state 80% token 0 - 20% token 1
         // Price in balanced state is 5e8
         uint256 token0PoolReserve = 1e18;

--- a/test/unit/LatestRoundData.t.sol
+++ b/test/unit/LatestRoundData.t.sol
@@ -5,17 +5,18 @@ import { BaseTest } from "test/Base.t.sol";
 import { FeedParams } from "test/utils/Types.sol";
 
 contract LatestRoundData_Unit_Test is BaseTest {
+    // Default prices for this test suite
+    int256 internal constant ANSWER0 = 4000e8;
+    int256 internal constant ANSWER1 = 1e8;
+
     function testFuzz_shouldRevert_LtEqZeroAnswer0(int256 answer0) external {
         vm.assume(answer0 < 0);
 
-        FeedParams memory feedParams0 =
-            FeedParams({ addr: FEED0, decimals: 8, answer: answer0, updatedAt: block.timestamp });
-        FeedParams memory feedParams1 =
-            FeedParams({ addr: FEED1, decimals: 8, answer: 1e8, updatedAt: block.timestamp });
+        (FeedParams memory feedParams0, FeedParams memory feedParams1) = defaults.mockFeedParams(answer0, 1e8);
 
         setPriceFeedData(feedParams0, feedParams1);
-        setMockOrder(1e18, 1e18, WEIGHT_50);
-        mock_pool_totalSupply(MOCK_POOL, LP_TOKEN_SUPPLY);
+        setMockOrder(1e18, 1e18, defaults.WEIGHT_50());
+        mock_pool_totalSupply(mocks.pool, defaults.LP_TOKEN_SUPPLY());
 
         vm.expectRevert();
         oracle.latestRoundData();
@@ -24,14 +25,11 @@ contract LatestRoundData_Unit_Test is BaseTest {
     function testFuzz_shouldRevert_LtEqZeroAnswer1(int256 answer1) external {
         vm.assume(answer1 < 0);
 
-        FeedParams memory feedParams0 =
-            FeedParams({ addr: FEED0, decimals: 8, answer: 1e8, updatedAt: block.timestamp });
-        FeedParams memory feedParams1 =
-            FeedParams({ addr: FEED1, decimals: 8, answer: answer1, updatedAt: block.timestamp });
+        (FeedParams memory feedParams0, FeedParams memory feedParams1) = defaults.mockFeedParams(1e8, answer1);
 
         setPriceFeedData(feedParams0, feedParams1);
-        setMockOrder(1e18, 1e18, WEIGHT_50);
-        mock_pool_totalSupply(MOCK_POOL, LP_TOKEN_SUPPLY);
+        setMockOrder(1e18, 1e18, defaults.WEIGHT_50());
+        mock_pool_totalSupply(mocks.pool, defaults.LP_TOKEN_SUPPLY());
 
         vm.expectRevert();
         oracle.latestRoundData();
@@ -46,17 +44,14 @@ contract LatestRoundData_Unit_Test is BaseTest {
     }
 
     function test_50_50Pool() external whenPositivePrices whenBalancedPool {
-        FeedParams memory feedParams0 =
-            FeedParams({ addr: FEED0, decimals: 8, answer: 4000e8, updatedAt: block.timestamp });
-        FeedParams memory feedParams1 =
-            FeedParams({ addr: FEED1, decimals: 8, answer: 1e8, updatedAt: block.timestamp });
+        (FeedParams memory feedParams0, FeedParams memory feedParams1) = defaults.mockFeedParams(ANSWER0, ANSWER1);
         setPriceFeedData(feedParams0, feedParams1);
 
         uint256 token0PoolReserve = 1e18;
         uint256 token1PoolReserve = 4000e18;
-        setMockOrder(token0PoolReserve, token1PoolReserve, WEIGHT_50);
+        setMockOrder(token0PoolReserve, token1PoolReserve, defaults.WEIGHT_50());
 
-        mock_pool_totalSupply(MOCK_POOL, LP_TOKEN_SUPPLY);
+        mock_pool_totalSupply(mocks.pool, defaults.LP_TOKEN_SUPPLY());
 
         (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) =
             oracle.latestRoundData();
@@ -73,17 +68,14 @@ contract LatestRoundData_Unit_Test is BaseTest {
     }
 
     function test_80_20Pool() external whenPositivePrices whenBalancedPool {
-        FeedParams memory feedParams0 =
-            FeedParams({ addr: FEED0, decimals: 8, answer: 4000e8, updatedAt: block.timestamp });
-        FeedParams memory feedParams1 =
-            FeedParams({ addr: FEED1, decimals: 8, answer: 1e8, updatedAt: block.timestamp });
+        (FeedParams memory feedParams0, FeedParams memory feedParams1) = defaults.mockFeedParams(ANSWER0, ANSWER1);
         setPriceFeedData(feedParams0, feedParams1);
 
         uint256 token0PoolReserve = 1e18;
         uint256 token1PoolReserve = 1000e18;
-        setMockOrder(token0PoolReserve, token1PoolReserve, WEIGHT_80);
+        setMockOrder(token0PoolReserve, token1PoolReserve, defaults.WEIGHT_80());
 
-        mock_pool_totalSupply(MOCK_POOL, LP_TOKEN_SUPPLY);
+        mock_pool_totalSupply(mocks.pool, defaults.LP_TOKEN_SUPPLY());
 
         (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) =
             oracle.latestRoundData();
@@ -104,10 +96,7 @@ contract LatestRoundData_Unit_Test is BaseTest {
     }
 
     function test_50_50Pool_LargeUnbalancing_TooMuchToken0() external whenPositivePrices whenUnbalancedPool {
-        FeedParams memory feedParams0 =
-            FeedParams({ addr: FEED0, decimals: 8, answer: 4000e8, updatedAt: block.timestamp });
-        FeedParams memory feedParams1 =
-            FeedParams({ addr: FEED1, decimals: 8, answer: 1e8, updatedAt: block.timestamp });
+        (FeedParams memory feedParams0, FeedParams memory feedParams1) = defaults.mockFeedParams(ANSWER0, ANSWER1);
 
         // Initial balanced pool state
         uint256 token0PoolReserve = 1e18;
@@ -117,20 +106,21 @@ contract LatestRoundData_Unit_Test is BaseTest {
         // Assume: zero swap fees. Out token is token0.
         // tokenAmountOut is set to the maximum amount before reverting due to: BNum_BPowBaseTooHigh()
         uint256 tokenAmountOut = 0.5e18 - 1 wei;
-        uint256 tokenAmountIn =
-            calcInGivenOut(token1PoolReserve, WEIGHT_50, token0PoolReserve, WEIGHT_50, tokenAmountOut, 0);
+        uint256 tokenAmountIn = calcInGivenOut(
+            token1PoolReserve, defaults.WEIGHT_50(), token0PoolReserve, defaults.WEIGHT_50(), tokenAmountOut, 0
+        );
         token0PoolReserve -= tokenAmountOut;
         token1PoolReserve += tokenAmountIn;
 
         // Mock calls
         setPriceFeedData(feedParams0, feedParams1);
-        setMockOrder(token0PoolReserve, token1PoolReserve, WEIGHT_50);
-        mock_pool_totalSupply(MOCK_POOL, LP_TOKEN_SUPPLY);
+        setMockOrder(token0PoolReserve, token1PoolReserve, defaults.WEIGHT_50());
+        mock_pool_totalSupply(mocks.pool, defaults.LP_TOKEN_SUPPLY());
 
         // Naive price
         // token0PoolReserve ≈ 0.5e8 token 0, token1PoolReserve ≈ 8000e18 token 1
         // naivePrice ≈ 10e8 == (0.5 * 4000 + 8000 * 1)
-        uint256 naivePrice = (token0PoolReserve * 4000e8 + token1PoolReserve * 1e8) / LP_TOKEN_SUPPLY;
+        uint256 naivePrice = (token0PoolReserve * 4000e8 + token1PoolReserve * 1e8) / defaults.LP_TOKEN_SUPPLY();
 
         // LP price
         (, int256 answer,,,) = oracle.latestRoundData();
@@ -143,10 +133,7 @@ contract LatestRoundData_Unit_Test is BaseTest {
     }
 
     function test_50_50Pool_LargeUnbalancing_TooMuchToken1() external whenPositivePrices whenUnbalancedPool {
-        FeedParams memory feedParams0 =
-            FeedParams({ addr: FEED0, decimals: 8, answer: 4000e8, updatedAt: block.timestamp });
-        FeedParams memory feedParams1 =
-            FeedParams({ addr: FEED1, decimals: 8, answer: 1e8, updatedAt: block.timestamp });
+        (FeedParams memory feedParams0, FeedParams memory feedParams1) = defaults.mockFeedParams(ANSWER0, ANSWER1);
 
         // Initial balanced pool state
         uint256 token0PoolReserve = 1e18;
@@ -156,20 +143,21 @@ contract LatestRoundData_Unit_Test is BaseTest {
         // Assume: zero swap fees. Out token is token1.
         // tokenAmountOut is set to the maximum amount before reverting due to: BNum_BPowBaseTooHigh()
         uint256 tokenAmountOut = 1999e18;
-        uint256 tokenAmountIn =
-            calcInGivenOut(token0PoolReserve, WEIGHT_50, token1PoolReserve, WEIGHT_50, tokenAmountOut, 0);
+        uint256 tokenAmountIn = calcInGivenOut(
+            token0PoolReserve, defaults.WEIGHT_50(), token1PoolReserve, defaults.WEIGHT_50(), tokenAmountOut, 0
+        );
         token1PoolReserve -= tokenAmountOut;
         token0PoolReserve += tokenAmountIn;
 
         // Mock calls
         setPriceFeedData(feedParams0, feedParams1);
-        setMockOrder(token0PoolReserve, token1PoolReserve, WEIGHT_50);
-        mock_pool_totalSupply(MOCK_POOL, LP_TOKEN_SUPPLY);
+        setMockOrder(token0PoolReserve, token1PoolReserve, defaults.WEIGHT_50());
+        mock_pool_totalSupply(mocks.pool, defaults.LP_TOKEN_SUPPLY());
 
         // Naive price
         // token0PoolReserve ≈ 0.5e8 token 0, token1PoolReserve ≈ 8000e18 token 1
         // naivePrice ≈ 10e8 == (2 * 4000 + 2000 * 1)
-        uint256 naivePrice = (token0PoolReserve * 4000e8 + token1PoolReserve * 1e8) / LP_TOKEN_SUPPLY;
+        uint256 naivePrice = (token0PoolReserve * 4000e8 + token1PoolReserve * 1e8) / defaults.LP_TOKEN_SUPPLY();
 
         // LP price
         (, int256 answer,,,) = oracle.latestRoundData();
@@ -182,10 +170,7 @@ contract LatestRoundData_Unit_Test is BaseTest {
     }
 
     function test_80_20Pool_LargeUnbalancing_TooMuchToken0() external whenPositivePrices whenUnbalancedPool {
-        FeedParams memory feedParams0 =
-            FeedParams({ addr: FEED0, decimals: 8, answer: 4000e8, updatedAt: block.timestamp });
-        FeedParams memory feedParams1 =
-            FeedParams({ addr: FEED1, decimals: 8, answer: 1e8, updatedAt: block.timestamp });
+        (FeedParams memory feedParams0, FeedParams memory feedParams1) = defaults.mockFeedParams(ANSWER0, ANSWER1);
 
         // Initial balanced pool state 80% token 0 - 20% token 1
         // Price in balanced state is 5e8
@@ -194,20 +179,21 @@ contract LatestRoundData_Unit_Test is BaseTest {
 
         // Mock calls
         setPriceFeedData(feedParams0, feedParams1);
-        setMockOrder(token0PoolReserve, token1PoolReserve, WEIGHT_80); // 3rd input is token0 weight
-        mock_pool_totalSupply(MOCK_POOL, LP_TOKEN_SUPPLY);
+        setMockOrder(token0PoolReserve, token1PoolReserve, defaults.WEIGHT_80()); // 3rd input is token0 weight
+        mock_pool_totalSupply(mocks.pool, defaults.LP_TOKEN_SUPPLY());
 
         // Next pool state: attacker unbalances the pool
         // Assume: zero swap fees. Out token is token0.
         // tokenAmountOut is set to approx. max amount before reverting due to: BNum_BPowBaseTooHigh()
         uint256 tokenAmountOut = 0.5e18 - 1 wei;
-        uint256 tokenAmountIn =
-            calcInGivenOut(token1PoolReserve, WEIGHT_20, token0PoolReserve, WEIGHT_80, tokenAmountOut, 0);
+        uint256 tokenAmountIn = calcInGivenOut(
+            token1PoolReserve, defaults.WEIGHT_20(), token0PoolReserve, defaults.WEIGHT_80(), tokenAmountOut, 0
+        );
         token0PoolReserve -= tokenAmountOut;
         token1PoolReserve += tokenAmountIn;
 
         // NaivePrice ≈ 18e8 == (0.5 * 4000 + 16000 * 1)
-        uint256 naivePrice = (token0PoolReserve * 4000e8 + token1PoolReserve * 1e8) / LP_TOKEN_SUPPLY;
+        uint256 naivePrice = (token0PoolReserve * 4000e8 + token1PoolReserve * 1e8) / defaults.LP_TOKEN_SUPPLY();
 
         // LP price
         (, int256 answer,,,) = oracle.latestRoundData();
@@ -219,41 +205,41 @@ contract LatestRoundData_Unit_Test is BaseTest {
         assertApproxEqRel(uint256(answer), 5e8, 1e15);
     }
 
-    function test_80_20Pool_LargeUnbalancing_TooMuchToken1() external whenPositivePrices whenUnbalancedPool {
-        FeedParams memory feedParams0 =
-            FeedParams({ addr: FEED0, decimals: 8, answer: 4000e8, updatedAt: block.timestamp });
-        FeedParams memory feedParams1 =
-            FeedParams({ addr: FEED1, decimals: 8, answer: 1e8, updatedAt: block.timestamp });
-
-        // Initial balanced pool state 80% token 0 - 20% token 1
-        // Price in balanced state is 5e8
-        uint256 token0PoolReserve = 1e18;
-        uint256 token1PoolReserve = 1000e18;
-
-        // Mock calls
-        setPriceFeedData(feedParams0, feedParams1);
-        setMockOrder(token0PoolReserve, token1PoolReserve, WEIGHT_80); // 3rd input is token0 weight
-        mock_pool_totalSupply(MOCK_POOL, LP_TOKEN_SUPPLY);
-
-        // Next pool state: attacker unbalances the pool
-        // Assume: zero swap fees. Out token is token1.
-        // tokenAmountOut is set to approx. max amount before reverting due to: BNum_BPowBaseTooHigh()
-        uint256 tokenAmountOut = 499e18;
-        uint256 tokenAmountIn =
-            calcInGivenOut(token0PoolReserve, WEIGHT_80, token1PoolReserve, WEIGHT_20, tokenAmountOut, 0);
-        token1PoolReserve -= tokenAmountOut;
-        token0PoolReserve += tokenAmountIn;
-
-        // NaivePrice ≈ 10e8 == (0.5 * 4000 + 16000 * 1)
-        uint256 naivePrice = (token0PoolReserve * 4000e8 + token1PoolReserve * 1e8) / LP_TOKEN_SUPPLY;
-
-        // LP price
-        (, int256 answer,,,) = oracle.latestRoundData();
-
-        // Assertions
-        // The naive LP token price is approx 6% higher than balanced pool price.
-        assertApproxEqRel(naivePrice, 5e8, 6e16);
-        // LP token price is within 0.1% of the balance pool price.
-        assertApproxEqRel(uint256(answer), 5e8, 1e15);
-    }
+    // @todo @lumoswiz this test is failing due to OutOfGas. Revist after test refactor.
+    //    function test_80_20Pool_LargeUnbalancing_TooMuchToken1() external whenPositivePrices whenUnbalancedPool {
+    //        (FeedParams memory feedParams0, FeedParams memory feedParams1) = defaults.mockFeedParams(ANSWER0,
+    // ANSWER1);
+    //
+    //        // Initial balanced pool state 80% token 0 - 20% token 1
+    //        // Price in balanced state is 5e8
+    //        uint256 token0PoolReserve = 1e18;
+    //        uint256 token1PoolReserve = 1000e18;
+    //
+    //        // Mock calls
+    //        setPriceFeedData(feedParams0, feedParams1);
+    //        setMockOrder(token0PoolReserve, token1PoolReserve, defaults.WEIGHT_80()); // 3rd input is token0 weight
+    //        mock_pool_totalSupply(mocks.pool, defaults.LP_TOKEN_SUPPLY());
+    //
+    //        // Next pool state: attacker unbalances the pool
+    //        // Assume: zero swap fees. Out token is token1.
+    //        // tokenAmountOut is set to approx. max amount before reverting due to: BNum_BPowBaseTooHigh()
+    //        uint256 tokenAmountOut = 499_999_999_999_999_999_749;
+    //        uint256 tokenAmountIn = calcInGivenOut(
+    //            token0PoolReserve, defaults.WEIGHT_80(), token1PoolReserve, defaults.WEIGHT_20(), tokenAmountOut, 0
+    //        );
+    //        token1PoolReserve -= tokenAmountOut;
+    //        token0PoolReserve += tokenAmountIn;
+    //
+    //        // NaivePrice ≈ 10e8 == (0.5 * 4000 + 16000 * 1)
+    //        uint256 naivePrice = (token0PoolReserve * 4000e8 + token1PoolReserve * 1e8) / defaults.LP_TOKEN_SUPPLY();
+    //
+    //        // LP price
+    //        (, int256 answer,,,) = oracle.latestRoundData();
+    //
+    //        // Assertions
+    //        // The naive LP token price is approx 6% higher than balanced pool price.
+    //        assertApproxEqRel(naivePrice, 5e8, 6e16);
+    //        // LP token price is within 0.1% of the balance pool price.
+    //        assertApproxEqRel(uint256(answer), 5e8, 1e15);
+    //    }
 }

--- a/test/unit/NormalizePrices.t.sol
+++ b/test/unit/NormalizePrices.t.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.25;
 
 import { BaseTest } from "test/Base.t.sol";
+import { ExposedLPOracle } from "test/harness/ExposedLPOracle.sol";
 
 contract NormalizePrices_Unit_Test is BaseTest {
     function test_normalizePrices() public view {
@@ -59,5 +60,15 @@ contract NormalizePrices_Unit_Test is BaseTest {
             1e16, // 1% tolerance
             "Relative price calculation incorrect"
         );
+    }
+
+    /*----------------------------------------------------------*|
+    |*  # HELPERS                                               *|
+    |*----------------------------------------------------------*/
+
+    /// @dev Helper to reinitialize oracle after changing decimals
+    function reinitOracle(uint8 decimals0, uint8 decimals1) internal {
+        setAllAddressDecimals(8, 8, decimals0, decimals1);
+        oracle = new ExposedLPOracle(mocks.pool, address(helper), mocks.feed0, mocks.feed1);
     }
 }

--- a/test/unit/OracleFactory.t.sol
+++ b/test/unit/OracleFactory.t.sol
@@ -28,13 +28,13 @@ contract OracleFactoryBenchmark is BaseTest {
     function _benchmarkFactory(LPOracleFactory _factory) private returns (BenchmarkResult memory) {
         vm.record();
         uint256 gasStart = gasleft();
-        _factory.deployOracle(MOCK_POOL, FEED0, FEED1);
+        _factory.deployOracle(mocks.pool, mocks.feed0, mocks.feed1);
         uint256 gasUsed = gasStart - gasleft();
 
         (bytes32[] memory reads, bytes32[] memory writes) = vm.accesses(address(factory));
 
         uint256 gasStart2 = gasleft();
-        _factory.computeOracleAddress(MOCK_POOL, FEED0, FEED1);
+        _factory.computeOracleAddress(mocks.pool, mocks.feed0, mocks.feed1);
         uint256 gasUsed2 = gasStart2 - gasleft();
         return BenchmarkResult({
             gasUsedDeploy: gasUsed,
@@ -60,15 +60,15 @@ contract OracleFactoryBenchmark is BaseTest {
 
     function test_Benchmark_VerifyAddressConsistency() public {
         // Deploy oracles
-        address oracle = factory.deployOracle(MOCK_POOL, FEED0, FEED1);
+        address oracle = factory.deployOracle(mocks.pool, mocks.feed0, mocks.feed1);
 
         // Verify computed addresses match deployed addresses
-        assertEq(factory.computeOracleAddress(MOCK_POOL, FEED0, FEED1), oracle, "Factory");
+        assertEq(factory.computeOracleAddress(mocks.pool, mocks.feed0, mocks.feed1), oracle, "Factory");
     }
 
     function test_DeployedOracleIsValid() public {
         // Deploy oracle
-        address oracleAddr = factory.deployOracle(MOCK_POOL, FEED0, FEED1);
+        address oracleAddr = factory.deployOracle(mocks.pool, mocks.feed0, mocks.feed1);
 
         // Verify oracle was deployed successfully
         assertTrue(oracleAddr != address(0), "Oracle not deployed");
@@ -77,10 +77,10 @@ contract OracleFactoryBenchmark is BaseTest {
         LPOracle oracle = LPOracle(oracleAddr);
 
         // Verify oracle initialization parameters
-        assertEq(oracle.POOL(), MOCK_POOL, "Wrong pool address");
+        assertEq(oracle.POOL(), mocks.pool, "Wrong pool address");
         assertEq(address(oracle.HELPER()), address(helper), "Wrong helper address");
-        assertEq(address(oracle.FEED0()), FEED0, "Wrong feed0 address");
-        assertEq(address(oracle.FEED1()), FEED1, "Wrong feed1 address");
+        assertEq(address(oracle.FEED0()), mocks.feed0, "Wrong feed0 address");
+        assertEq(address(oracle.FEED1()), mocks.feed1, "Wrong feed1 address");
 
         // TODO(bh2smith): We would need to add some additional mocking to test this functionality.
         // // Verify oracle can be called (this will revert if oracle is not properly initialized)
@@ -93,16 +93,16 @@ contract OracleFactoryBenchmark is BaseTest {
         // }
 
         // Verify oracle is registered in factory
-        assertEq(factory.getOracle(MOCK_POOL), oracleAddr, "Oracle not registered in factory");
+        assertEq(factory.getOracle(mocks.pool), oracleAddr, "Oracle not registered in factory");
         console.log("Oracle address:", oracleAddr);
     }
 
     function test_CannotDeployDuplicateOracle() public {
         // Deploy first oracle
-        factory.deployOracle(MOCK_POOL, FEED0, FEED1);
+        factory.deployOracle(mocks.pool, mocks.feed0, mocks.feed1);
 
         // Attempt to deploy second oracle for same pool
         vm.expectRevert(abi.encodeWithSignature("OracleAlreadyExists()"));
-        factory.deployOracle(MOCK_POOL, FEED0, FEED1);
+        factory.deployOracle(mocks.pool, mocks.feed0, mocks.feed1);
     }
 }

--- a/test/unit/SimulateOrder.t.sol
+++ b/test/unit/SimulateOrder.t.sol
@@ -39,9 +39,9 @@ contract SimulateOrder_Unit_Test is BaseTest {
         setMockOrder(token0PoolReserve, token1PoolReserve, 0.5e18);
         GPv2Order.Data memory order = oracle.exposed_simulateOrder(price0, price1);
         // Pool needs to sell off token0.
-        assertEq(TOKEN0, address(order.sellToken));
+        assertEq(mocks.token0, address(order.sellToken));
         // Pool needs to buy token1.
-        assertEq(TOKEN1, address(order.buyToken));
+        assertEq(mocks.token1, address(order.buyToken));
     }
 
     function test_SimulateOrder_Balanced50_50Pool() external whenNonZeroPrices {

--- a/test/unit/SimulatePoolReserves.t.sol
+++ b/test/unit/SimulatePoolReserves.t.sol
@@ -7,12 +7,12 @@ import { GPv2Order } from "cowprotocol/contracts/libraries/GPv2Order.sol";
 
 contract SimulatePoolReserves_Unit_Test is BaseTest {
     function test_SimulatePoolReserves_Balanced50_50Pool() external {
-        setMockOrder(TOKEN0_BALANCE, TOKEN1_BALANCE, NORMALIZED_WEIGHT);
+        setMockOrder(defaults.TOKEN0_BALANCE(), defaults.TOKEN1_BALANCE(), defaults.NORMALIZED_WEIGHT());
         GPv2Order.Data memory order = oracle.exposed_simulateOrder(1e8, 1e8);
 
         (uint256 token0Bal, uint256 token1Bal) = oracle.exposed_simulatePoolReserves(order);
-        assertEq(token0Bal, TOKEN0_BALANCE);
-        assertEq(token1Bal, TOKEN1_BALANCE);
+        assertEq(token0Bal, defaults.TOKEN0_BALANCE());
+        assertEq(token1Bal, defaults.TOKEN1_BALANCE());
     }
 
     function test_SimulatePoolReserves_Balanced80_20Pool() external {

--- a/test/utils/Calculations.sol
+++ b/test/utils/Calculations.sol
@@ -6,10 +6,11 @@ import { BMath } from "@balancer/cow-amm/src/contracts/BMath.sol";
 /// @dev Helper contract for calculations required in testing.
 contract Calculations is BMath {
     /// @dev Returns the maximum tokenAmountOut for a given balanceAmountOut for BMath.calcInGivenOut
-    function maxAmountOutGivenBalanceOut(uint256 bO) internal pure returns (uint256) {
-        uint256 x = bmul(bO, MAX_BPOW_BASE);
-        uint256 y = bsub(x, bO);
-        uint256 aO = bdiv(y, MAX_BPOW_BASE) - 1 wei;
-        return aO;
+    /// Returns 99.96% of the max amount to avoid OutOfGas reverts.
+    function maxAmountOutGivenBalanceOut(uint256 tokenBalanceOut) internal pure returns (uint256) {
+        uint256 x = bmul(tokenBalanceOut, MAX_BPOW_BASE);
+        uint256 y = bsub(x, tokenBalanceOut);
+        uint256 maxTokenAmountOut = bdiv(y, MAX_BPOW_BASE) - 1 wei;
+        return (maxTokenAmountOut * 9996) / 1e4;
     }
 }

--- a/test/utils/Calculations.sol
+++ b/test/utils/Calculations.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity >=0.8.25 < 0.9.0;
+
+import { BMath } from "@balancer/cow-amm/src/contracts/BMath.sol";
+
+/// @dev Helper contract for calculations required in testing.
+contract Calculations is BMath {
+    /// @dev Returns the maximum tokenAmountOut for a given balanceAmountOut for BMath.calcInGivenOut
+    function maxAmountOutGivenBalanceOut(uint256 bO) internal pure returns (uint256) {
+        uint256 x = bmul(bO, MAX_BPOW_BASE);
+        uint256 y = bsub(x, bO);
+        uint256 aO = bdiv(y, MAX_BPOW_BASE) - 1 wei;
+        return aO;
+    }
+}

--- a/test/utils/Constants.sol
+++ b/test/utils/Constants.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity >=0.8.25 < 0.9.0;
+
+import { BConst } from "@balancer/cow-amm/src/contracts/BConst.sol";
+
+contract Constants is BConst {
+    uint256 public constant DEC_1_2024 = 1_733_011_200;
+}

--- a/test/utils/Defaults.sol
+++ b/test/utils/Defaults.sol
@@ -17,6 +17,9 @@ contract Defaults is Constants {
 
     uint8 public constant FEED_DECIMALS = 8;
 
+    int256 public constant ANSWER0 = 4000e8;
+    int256 public constant ANSWER1 = 1e8;
+
     Mocks private mocks;
 
     /*----------------------------------------------------------*|

--- a/test/utils/Defaults.sol
+++ b/test/utils/Defaults.sol
@@ -1,15 +1,74 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.8.25 < 0.9.0;
 
-contract Defaults {
-    uint256 internal constant TOKEN0_BALANCE = 1e18;
-    uint256 internal constant TOKEN1_BALANCE = 1e18;
-    uint256 internal constant NORMALIZED_WEIGHT = 0.5e18;
-    uint256 internal constant DENORMALIZED_WEIGHT = 1e18;
-    bytes32 internal constant APP_DATA = keccak256("APP_DATA");
-    uint256 internal constant DEC_1_2024 = 1_733_011_200;
-    uint256 internal constant LP_TOKEN_SUPPLY = 1000e18;
-    uint256 internal constant WEIGHT_20 = 0.2e18;
-    uint256 internal constant WEIGHT_50 = 0.5e18;
-    uint256 internal constant WEIGHT_80 = 0.8e18;
+import { Constants } from "test/utils/Constants.sol";
+import { Mocks, OrderParams, TokenParams, FeedParams } from "test/utils/Types.sol";
+
+contract Defaults is Constants {
+    uint256 public constant TOKEN0_BALANCE = 1e18;
+    uint256 public constant TOKEN1_BALANCE = 1e18;
+    uint256 public constant NORMALIZED_WEIGHT = 0.5e18;
+    uint256 public constant DENORMALIZED_WEIGHT = 1e18;
+    bytes32 public constant APP_DATA = keccak256("APP_DATA");
+    uint256 public constant LP_TOKEN_SUPPLY = 1000e18;
+    uint256 public constant WEIGHT_20 = 0.2e18;
+    uint256 public constant WEIGHT_50 = 0.5e18;
+    uint256 public constant WEIGHT_80 = 0.8e18;
+
+    uint8 public constant FEED_DECIMALS = 8;
+
+    Mocks private mocks;
+
+    /*----------------------------------------------------------*|
+    |*  # HELPERS                                               *|
+    |*----------------------------------------------------------*/
+
+    function setMocks(Mocks memory mocks_) public {
+        mocks = mocks_;
+    }
+
+    /*----------------------------------------------------------*|
+    |*  # STRUCTS                                               *|
+    |*----------------------------------------------------------*/
+
+    function mockOrderParamsCustomValues(
+        uint256 token0Balance,
+        uint256 token1Balance,
+        uint256 token0Weight
+    )
+        public
+        view
+        returns (OrderParams memory)
+    {
+        return OrderParams({
+            pool: mocks.pool,
+            factory: mocks.factory,
+            token0: TokenParams({
+                addr: mocks.token0,
+                balance: token0Balance,
+                normWeight: token0Weight,
+                denormWeight: DENORMALIZED_WEIGHT
+            }),
+            token1: TokenParams({
+                addr: mocks.token1,
+                balance: token1Balance,
+                normWeight: BONE - token0Weight,
+                denormWeight: DENORMALIZED_WEIGHT
+            })
+        });
+    }
+
+    function mockFeedParams(
+        int256 answer0,
+        int256 answer1
+    )
+        public
+        view
+        returns (FeedParams memory, FeedParams memory)
+    {
+        return (
+            FeedParams({ addr: mocks.feed0, decimals: FEED_DECIMALS, answer: answer0, updatedAt: block.timestamp }),
+            FeedParams({ addr: mocks.feed1, decimals: FEED_DECIMALS, answer: answer1, updatedAt: block.timestamp })
+        );
+    }
 }

--- a/test/utils/Types.sol
+++ b/test/utils/Types.sol
@@ -1,6 +1,15 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.8.25;
 
+struct Mocks {
+    address factory;
+    address pool;
+    address token0;
+    address token1;
+    address feed0;
+    address feed1;
+}
+
 struct TokenParams {
     address addr;
     uint256 balance;


### PR DESCRIPTION
This PR refactors the test suite to improve organization and testability by:

- Adopting a similar structure to Sablier V2 by introducing a Defaults contract for managing mock addresses and common testing patterns
- Creating dedicated utility contracts for test calculations and constants

## Next Steps
- Implementing calculations utilities to centralize common test calculations
- Reorganizing latestRoundData testing logic into grouped, focused test cases

## Key Improvements
The new `Calculations.maxAmountOutGivenBalanceOut` function will enable us to:
- Calculate the maximum output amount possible given specific pool balances
- Estimate the worst-case price deviation our oracle could experience from a single large trade that significantly impacts pool reserves
- Better understand and test the oracle's price boundaries under extreme market conditions