### PR TITLE
fix: underpricing bug from improper decimal handling

### DIFF
--- a/test/Base.t.sol
+++ b/test/Base.t.sol
@@ -105,4 +105,10 @@ contract BaseTest is Assertions, Calculations, Utils {
         setMockOrder(token0Balance, token1Balance, token0Weight);
         mock_pool_totalSupply(mocks.pool, defaults.LP_TOKEN_SUPPLY());
     }
+
+    /// @dev Helper to reinitialize oracle after changing decimals
+    function reinitOracle(uint8 decimals0, uint8 decimals1) internal {
+        setAllAddressDecimals(8, 8, decimals0, decimals1);
+        oracle = new ExposedLPOracle(mocks.pool, address(helper), mocks.feed0, mocks.feed1);
+    }
 }

--- a/test/unit/LatestRoundData.t.sol
+++ b/test/unit/LatestRoundData.t.sol
@@ -213,4 +213,22 @@ contract LatestRoundData_Unit_Test is BaseTest {
         // LP token price is within 0.1% of the balance pool price.
         assertApproxEqRel(uint256(answer), 5e8, 1e15);
     }
+
+    function test_BalancedPool_EqualTokenDecimals() external {
+        uint256 token0PoolReserve = 1e6;
+        uint256 token1PoolReserve = 4000e6;
+
+        // Reinit the oracle to set token decimals to 6 instead of 18
+        reinitOracle(6, 6);
+
+        setLatestRoundDataMocks(
+            defaults.ANSWER0(), defaults.ANSWER1(), token0PoolReserve, token1PoolReserve, defaults.WEIGHT_50()
+        );
+
+        (, int256 answer,,,) = oracle.latestRoundData();
+
+        // Implemented assertions
+        // Expected LP token USD price = (1 * 4000 + 4000 * 1) / 1000 = $8/token === 8e8
+        assertEq(answer, 8e8, "answer");
+    }
 }

--- a/test/unit/NormalizePrices.t.sol
+++ b/test/unit/NormalizePrices.t.sol
@@ -61,14 +61,4 @@ contract NormalizePrices_Unit_Test is BaseTest {
             "Relative price calculation incorrect"
         );
     }
-
-    /*----------------------------------------------------------*|
-    |*  # HELPERS                                               *|
-    |*----------------------------------------------------------*/
-
-    /// @dev Helper to reinitialize oracle after changing decimals
-    function reinitOracle(uint8 decimals0, uint8 decimals1) internal {
-        setAllAddressDecimals(8, 8, decimals0, decimals1);
-        oracle = new ExposedLPOracle(mocks.pool, address(helper), mocks.feed0, mocks.feed1);
-    }
 }


### PR DESCRIPTION
* added _calculatePrice method to LPOracle for calculating lp token price
* removed: use of _adjustDecimals in _simulatePoolReserves
* moved: reinitOracle to BaseTest from NormalizePrices.t.sol
* added test: test_BalancedPool_EqualTokenDecimals.

Fixes #25 