### PR TITLE
test: Add fuzz testing for latestRoundData with arbitrary pool params and imbalancing

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -2,7 +2,7 @@
 
 [profile.default]
 auto_detect_solc = false
-block_timestamp = 1_680_220_800 # March 31, 2023 at 00:00 GMT
+block_timestamp = 1_680_220_800                                   # March 31, 2023 at 00:00 GMT
 memory_limit = 128000000
 bytecode_hash = "none"
 evm_version = "cancun"
@@ -15,6 +15,7 @@ script = "script"
 solc = "0.8.25"
 src = "src"
 test = "test"
+fs_permissions = [{ access = "read-write", path = "./analysis" }]
 
 [profile.ci]
 fuzz = { runs = 10_000 }

--- a/foundry.toml
+++ b/foundry.toml
@@ -2,7 +2,7 @@
 
 [profile.default]
 auto_detect_solc = false
-block_timestamp = 1_680_220_800                                   # March 31, 2023 at 00:00 GMT
+block_timestamp = 1_680_220_800 # March 31, 2023 at 00:00 GMT
 memory_limit = 128000000
 bytecode_hash = "none"
 evm_version = "cancun"
@@ -15,7 +15,6 @@ script = "script"
 solc = "0.8.25"
 src = "src"
 test = "test"
-fs_permissions = [{ access = "read-write", path = "./analysis" }]
 
 [profile.ci]
 fuzz = { runs = 10_000 }

--- a/test/unit/latest-round-data/concrete/LatestRoundData.t.sol
+++ b/test/unit/latest-round-data/concrete/LatestRoundData.t.sol
@@ -217,8 +217,6 @@ contract LatestRoundData_Concrete_Unit_Test is BaseTest {
         uint256 token0PoolReserve = 1e18;
         uint256 token1PoolReserve = 3000e18;
 
-        setLatestRoundDataMocks(defaults.ANSWER0(), defaults.ANSWER1(), token0PoolReserve, token1PoolReserve);
-
         // Next pool state: too much token 1
         // token 0 out: amount == 0.9
         uint256 token0Amountout = 0.9e18;
@@ -227,6 +225,9 @@ contract LatestRoundData_Concrete_Unit_Test is BaseTest {
         );
         token0PoolReserve -= token0Amountout;
         token1PoolReserve += token1AmountIn;
+
+        // Mocks
+        setLatestRoundDataMocks(defaults.ANSWER0(), defaults.ANSWER1(), token0PoolReserve, token1PoolReserve);
 
         // naivePrice ≈ $30.3 / LP token == 30.3e8 == (0.1 * 3000 + 30000 * 1)
         uint256 naivePrice = (
@@ -261,8 +262,6 @@ contract LatestRoundData_Concrete_Unit_Test is BaseTest {
         uint256 token0PoolReserve = 1e18;
         uint256 token1PoolReserve = 3000e18;
 
-        setLatestRoundDataMocks(defaults.ANSWER0(), defaults.ANSWER1(), token0PoolReserve, token1PoolReserve);
-
         // Next pool state: too much token 0
         // token 1 out: amount == 2700
         uint256 token1Amountout = 2700e18;
@@ -271,6 +270,9 @@ contract LatestRoundData_Concrete_Unit_Test is BaseTest {
         );
         token0PoolReserve += token0AmountIn;
         token1PoolReserve -= token1Amountout;
+
+        // Mocks
+        setLatestRoundDataMocks(defaults.ANSWER0(), defaults.ANSWER1(), token0PoolReserve, token1PoolReserve);
 
         // naivePrice ≈ $30.3 / LP token == 30.3e8 == (10 * 3000 + 300 * 1)
         uint256 naivePrice = (
@@ -310,8 +312,6 @@ contract LatestRoundData_Concrete_Unit_Test is BaseTest {
         uint256 token0PoolReserve = 1e18;
         uint256 token1PoolReserve = 750e18;
 
-        setLatestRoundDataMocks(defaults.ANSWER0(), defaults.ANSWER1(), token0PoolReserve, token1PoolReserve);
-
         // Next pool state: too much token 1
         // token 0 out: amount == 0.5
         uint256 token0Amountout = 0.5e18;
@@ -320,6 +320,9 @@ contract LatestRoundData_Concrete_Unit_Test is BaseTest {
         );
         token0PoolReserve -= token0Amountout;
         token1PoolReserve += token1AmountIn;
+
+        // Mocks
+        setLatestRoundDataMocks(defaults.ANSWER0(), defaults.ANSWER1(), token0PoolReserve, token1PoolReserve);
 
         // NaivePrice: 0.5 * 3000 + 12000 * 1 = 13.5e8 == $13.5/lp token
         uint256 naivePrice = (
@@ -359,8 +362,6 @@ contract LatestRoundData_Concrete_Unit_Test is BaseTest {
         uint256 token0PoolReserve = 1e18;
         uint256 token1PoolReserve = 750e18;
 
-        setLatestRoundDataMocks(defaults.ANSWER0(), defaults.ANSWER1(), token0PoolReserve, token1PoolReserve);
-
         // Next pool state: too much token 0
         // token 1 out: amount == 250e8
         uint256 token1Amountout = 250e18;
@@ -369,6 +370,9 @@ contract LatestRoundData_Concrete_Unit_Test is BaseTest {
         );
         token0PoolReserve += token0AmountIn;
         token1PoolReserve -= token1Amountout;
+
+        // Mocks
+        setLatestRoundDataMocks(defaults.ANSWER0(), defaults.ANSWER1(), token0PoolReserve, token1PoolReserve);
 
         // NaivePrice: 1.11 * 3000 + 500 * 1 = 3.83e8 == $3.83/lp token
         uint256 naivePrice = (
@@ -493,6 +497,15 @@ contract LatestRoundData_Concrete_Unit_Test is BaseTest {
         int256 answer0 = 3000e8; // 8 decimal basis
         int256 answer1 = 1e18;
 
+        // Next pool state: too much token 1
+        // token 0 out: amount == 0.9
+        uint256 token0Amountout = 0.9e18;
+        uint256 token1AmountIn = calcInGivenOutSignedWadMath(
+            token1PoolReserve, defaults.WEIGHT_50(), token0PoolReserve, defaults.WEIGHT_50(), token0Amountout
+        );
+        token0PoolReserve -= token0Amountout;
+        token1PoolReserve += token1AmountIn;
+
         // Mocks
         setAllLatestRoundDataMocks(
             8,
@@ -505,15 +518,6 @@ contract LatestRoundData_Concrete_Unit_Test is BaseTest {
             token1PoolReserve,
             defaults.LP_TOKEN_SUPPLY()
         );
-
-        // Next pool state: too much token 1
-        // token 0 out: amount == 0.9
-        uint256 token0Amountout = 0.9e18;
-        uint256 token1AmountIn = calcInGivenOutSignedWadMath(
-            token1PoolReserve, defaults.WEIGHT_50(), token0PoolReserve, defaults.WEIGHT_50(), token0Amountout
-        );
-        token0PoolReserve -= token0Amountout;
-        token1PoolReserve += token1AmountIn;
 
         // naivePrice ≈ $30.3 / LP token == (0.1 * 3000 + 30000 * 1)
         uint256 naivePrice = (
@@ -550,6 +554,15 @@ contract LatestRoundData_Concrete_Unit_Test is BaseTest {
         int256 answer0 = 3000e8; // 8 decimal basis
         int256 answer1 = 1e18;
 
+        // Next pool state: too much token 0
+        // token 1 out: amount == 2700
+        uint256 token1Amountout = 2700e18;
+        uint256 token0AmountIn = calcInGivenOutSignedWadMath(
+            token0PoolReserve, defaults.WEIGHT_50(), token1PoolReserve, defaults.WEIGHT_50(), token1Amountout
+        );
+        token0PoolReserve += token0AmountIn;
+        token1PoolReserve -= token1Amountout;
+
         // Mocks
         setAllLatestRoundDataMocks(
             8,
@@ -562,15 +575,6 @@ contract LatestRoundData_Concrete_Unit_Test is BaseTest {
             token1PoolReserve,
             defaults.LP_TOKEN_SUPPLY()
         );
-
-        // Next pool state: too much token 0
-        // token 1 out: amount == 2700
-        uint256 token1Amountout = 2700e18;
-        uint256 token0AmountIn = calcInGivenOutSignedWadMath(
-            token0PoolReserve, defaults.WEIGHT_50(), token1PoolReserve, defaults.WEIGHT_50(), token1Amountout
-        );
-        token0PoolReserve += token0AmountIn;
-        token1PoolReserve -= token1Amountout;
 
         // naivePrice ≈ $30.3 / LP token == (10 * 3000 + 300 * 1)
         uint256 naivePrice = (
@@ -612,6 +616,15 @@ contract LatestRoundData_Concrete_Unit_Test is BaseTest {
         int256 answer0 = 3000e8; // 8 decimal basis
         int256 answer1 = 1e18;
 
+        // Next pool state: too much token 1
+        // token 0 out: amount == 0.5
+        uint256 token0Amountout = 0.5e18;
+        uint256 token1AmountIn = calcInGivenOutSignedWadMath(
+            token1PoolReserve, defaults.WEIGHT_20(), token0PoolReserve, defaults.WEIGHT_80(), token0Amountout
+        );
+        token0PoolReserve -= token0Amountout;
+        token1PoolReserve += token1AmountIn;
+
         // Mocks
         setAllLatestRoundDataMocks(
             8,
@@ -624,15 +637,6 @@ contract LatestRoundData_Concrete_Unit_Test is BaseTest {
             token1PoolReserve,
             defaults.LP_TOKEN_SUPPLY()
         );
-
-        // Next pool state: too much token 1
-        // token 0 out: amount == 0.5
-        uint256 token0Amountout = 0.5e18;
-        uint256 token1AmountIn = calcInGivenOutSignedWadMath(
-            token1PoolReserve, defaults.WEIGHT_20(), token0PoolReserve, defaults.WEIGHT_80(), token0Amountout
-        );
-        token0PoolReserve -= token0Amountout;
-        token1PoolReserve += token1AmountIn;
 
         // NaivePrice: 0.5 * 3000 + 12000 * 1 == $13.5/lp token
         uint256 naivePrice = (
@@ -674,6 +678,15 @@ contract LatestRoundData_Concrete_Unit_Test is BaseTest {
         int256 answer0 = 3000e8; // 8 decimal basis
         int256 answer1 = 1e18;
 
+        // Next pool state: too much token 0
+        // token 1 out: amount == 250e8
+        uint256 token1Amountout = 250e18;
+        uint256 token0AmountIn = calcInGivenOutSignedWadMath(
+            token0PoolReserve, defaults.WEIGHT_80(), token1PoolReserve, defaults.WEIGHT_20(), token1Amountout
+        );
+        token0PoolReserve += token0AmountIn;
+        token1PoolReserve -= token1Amountout;
+
         // Mocks
         setAllLatestRoundDataMocks(
             8,
@@ -686,15 +699,6 @@ contract LatestRoundData_Concrete_Unit_Test is BaseTest {
             token1PoolReserve,
             defaults.LP_TOKEN_SUPPLY()
         );
-
-        // Next pool state: too much token 0
-        // token 1 out: amount == 250e8
-        uint256 token1Amountout = 250e18;
-        uint256 token0AmountIn = calcInGivenOutSignedWadMath(
-            token0PoolReserve, defaults.WEIGHT_80(), token1PoolReserve, defaults.WEIGHT_20(), token1Amountout
-        );
-        token0PoolReserve += token0AmountIn;
-        token1PoolReserve -= token1Amountout;
 
         // NaivePrice: 1.11 * 3000 + 500 * 1 = $3.83/lp token
         uint256 naivePrice = (

--- a/test/unit/latest-round-data/concrete/LatestRoundData.t.sol
+++ b/test/unit/latest-round-data/concrete/LatestRoundData.t.sol
@@ -219,11 +219,11 @@ contract LatestRoundData_Concrete_Unit_Test is BaseTest {
 
         // Next pool state: too much token 1
         // token 0 out: amount == 0.9
-        uint256 token0Amountout = 0.9e18;
+        uint256 token0AmountOut = 0.9e18;
         uint256 token1AmountIn = calcInGivenOutSignedWadMath(
-            token1PoolReserve, defaults.WEIGHT_50(), token0PoolReserve, defaults.WEIGHT_50(), token0Amountout
+            token1PoolReserve, defaults.WEIGHT_50(), token0PoolReserve, defaults.WEIGHT_50(), token0AmountOut
         );
-        token0PoolReserve -= token0Amountout;
+        token0PoolReserve -= token0AmountOut;
         token1PoolReserve += token1AmountIn;
 
         // Mocks
@@ -264,12 +264,12 @@ contract LatestRoundData_Concrete_Unit_Test is BaseTest {
 
         // Next pool state: too much token 0
         // token 1 out: amount == 2700
-        uint256 token1Amountout = 2700e18;
+        uint256 token1AmountOut = 2700e18;
         uint256 token0AmountIn = calcInGivenOutSignedWadMath(
-            token0PoolReserve, defaults.WEIGHT_50(), token1PoolReserve, defaults.WEIGHT_50(), token1Amountout
+            token0PoolReserve, defaults.WEIGHT_50(), token1PoolReserve, defaults.WEIGHT_50(), token1AmountOut
         );
         token0PoolReserve += token0AmountIn;
-        token1PoolReserve -= token1Amountout;
+        token1PoolReserve -= token1AmountOut;
 
         // Mocks
         setLatestRoundDataMocks(defaults.ANSWER0(), defaults.ANSWER1(), token0PoolReserve, token1PoolReserve);
@@ -314,11 +314,11 @@ contract LatestRoundData_Concrete_Unit_Test is BaseTest {
 
         // Next pool state: too much token 1
         // token 0 out: amount == 0.5
-        uint256 token0Amountout = 0.5e18;
+        uint256 token0AmountOut = 0.5e18;
         uint256 token1AmountIn = calcInGivenOutSignedWadMath(
-            token1PoolReserve, defaults.WEIGHT_20(), token0PoolReserve, defaults.WEIGHT_80(), token0Amountout
+            token1PoolReserve, defaults.WEIGHT_20(), token0PoolReserve, defaults.WEIGHT_80(), token0AmountOut
         );
-        token0PoolReserve -= token0Amountout;
+        token0PoolReserve -= token0AmountOut;
         token1PoolReserve += token1AmountIn;
 
         // Mocks
@@ -364,12 +364,12 @@ contract LatestRoundData_Concrete_Unit_Test is BaseTest {
 
         // Next pool state: too much token 0
         // token 1 out: amount == 250e8
-        uint256 token1Amountout = 250e18;
+        uint256 token1AmountOut = 250e18;
         uint256 token0AmountIn = calcInGivenOutSignedWadMath(
-            token0PoolReserve, defaults.WEIGHT_80(), token1PoolReserve, defaults.WEIGHT_20(), token1Amountout
+            token0PoolReserve, defaults.WEIGHT_80(), token1PoolReserve, defaults.WEIGHT_20(), token1AmountOut
         );
         token0PoolReserve += token0AmountIn;
-        token1PoolReserve -= token1Amountout;
+        token1PoolReserve -= token1AmountOut;
 
         // Mocks
         setLatestRoundDataMocks(defaults.ANSWER0(), defaults.ANSWER1(), token0PoolReserve, token1PoolReserve);
@@ -499,11 +499,11 @@ contract LatestRoundData_Concrete_Unit_Test is BaseTest {
 
         // Next pool state: too much token 1
         // token 0 out: amount == 0.9
-        uint256 token0Amountout = 0.9e18;
+        uint256 token0AmountOut = 0.9e18;
         uint256 token1AmountIn = calcInGivenOutSignedWadMath(
-            token1PoolReserve, defaults.WEIGHT_50(), token0PoolReserve, defaults.WEIGHT_50(), token0Amountout
+            token1PoolReserve, defaults.WEIGHT_50(), token0PoolReserve, defaults.WEIGHT_50(), token0AmountOut
         );
-        token0PoolReserve -= token0Amountout;
+        token0PoolReserve -= token0AmountOut;
         token1PoolReserve += token1AmountIn;
 
         // Mocks
@@ -556,12 +556,12 @@ contract LatestRoundData_Concrete_Unit_Test is BaseTest {
 
         // Next pool state: too much token 0
         // token 1 out: amount == 2700
-        uint256 token1Amountout = 2700e18;
+        uint256 token1AmountOut = 2700e18;
         uint256 token0AmountIn = calcInGivenOutSignedWadMath(
-            token0PoolReserve, defaults.WEIGHT_50(), token1PoolReserve, defaults.WEIGHT_50(), token1Amountout
+            token0PoolReserve, defaults.WEIGHT_50(), token1PoolReserve, defaults.WEIGHT_50(), token1AmountOut
         );
         token0PoolReserve += token0AmountIn;
-        token1PoolReserve -= token1Amountout;
+        token1PoolReserve -= token1AmountOut;
 
         // Mocks
         setAllLatestRoundDataMocks(
@@ -618,11 +618,11 @@ contract LatestRoundData_Concrete_Unit_Test is BaseTest {
 
         // Next pool state: too much token 1
         // token 0 out: amount == 0.5
-        uint256 token0Amountout = 0.5e18;
+        uint256 token0AmountOut = 0.5e18;
         uint256 token1AmountIn = calcInGivenOutSignedWadMath(
-            token1PoolReserve, defaults.WEIGHT_20(), token0PoolReserve, defaults.WEIGHT_80(), token0Amountout
+            token1PoolReserve, defaults.WEIGHT_20(), token0PoolReserve, defaults.WEIGHT_80(), token0AmountOut
         );
-        token0PoolReserve -= token0Amountout;
+        token0PoolReserve -= token0AmountOut;
         token1PoolReserve += token1AmountIn;
 
         // Mocks
@@ -680,12 +680,12 @@ contract LatestRoundData_Concrete_Unit_Test is BaseTest {
 
         // Next pool state: too much token 0
         // token 1 out: amount == 250e8
-        uint256 token1Amountout = 250e18;
+        uint256 token1AmountOut = 250e18;
         uint256 token0AmountIn = calcInGivenOutSignedWadMath(
-            token0PoolReserve, defaults.WEIGHT_80(), token1PoolReserve, defaults.WEIGHT_20(), token1Amountout
+            token0PoolReserve, defaults.WEIGHT_80(), token1PoolReserve, defaults.WEIGHT_20(), token1AmountOut
         );
         token0PoolReserve += token0AmountIn;
-        token1PoolReserve -= token1Amountout;
+        token1PoolReserve -= token1AmountOut;
 
         // Mocks
         setAllLatestRoundDataMocks(

--- a/test/unit/latest-round-data/fuzz/LatestRoundData.t.sol
+++ b/test/unit/latest-round-data/fuzz/LatestRoundData.t.sol
@@ -127,6 +127,7 @@ contract LatestRoundData_Fuzz_Unit_Test is BaseTest {
         // Assertions
         // For a balanced pool, `naivePrice` and oracle answer should be the same
         assertApproxEqRel(uint256(answer), naivePrice, 1e15); // 100% == 1e18
+        assertGt(uint256(answer), 0);
     }
 
     modifier whenUnbalancedPool() {
@@ -197,6 +198,7 @@ contract LatestRoundData_Fuzz_Unit_Test is BaseTest {
 
         // Assertions
         assertGt(naivePrice, uint256(answer));
+        assertGt(uint256(answer), 0);
         // @ todo: is this useful?
         // uint256 diff = stdMath.percentDelta(uint256(answer), naivePrice);
     }
@@ -263,6 +265,7 @@ contract LatestRoundData_Fuzz_Unit_Test is BaseTest {
 
         // Assertions
         assertGt(naivePrice, uint256(answer));
+        assertGt(uint256(answer), 0);
         // @ todo: is this useful?
         // uint256 diff = stdMath.percentDelta(uint256(answer), naivePrice);
     }

--- a/test/unit/latest-round-data/fuzz/LatestRoundData.t.sol
+++ b/test/unit/latest-round-data/fuzz/LatestRoundData.t.sol
@@ -168,11 +168,11 @@ contract LatestRoundData_Fuzz_Unit_Test is BaseTest {
             calcToken0FromToken1(decimals, decimals, answer0, answer1, weight0, token1PoolReserve);
 
         // Next pool state
-        uint256 token0Amountout = (outFrac * token0PoolReserve) / 1e4;
+        uint256 token0AmountOut = (outFrac * token0PoolReserve) / 1e4;
         uint256 token1AmountIn =
-            calcInGivenOutSignedWadMath(token1PoolReserve, 1e18 - weight0, token0PoolReserve, weight0, token0Amountout);
+            calcInGivenOutSignedWadMath(token1PoolReserve, 1e18 - weight0, token0PoolReserve, weight0, token0AmountOut);
 
-        token0PoolReserve -= token0Amountout;
+        token0PoolReserve -= token0AmountOut;
         token1PoolReserve += token1AmountIn;
 
         // Mocks

--- a/test/unit/latest-round-data/fuzz/LatestRoundData.t.sol
+++ b/test/unit/latest-round-data/fuzz/LatestRoundData.t.sol
@@ -7,8 +7,37 @@ import { IERC20 } from "cowprotocol/contracts/interfaces/IERC20.sol";
 import { stdError } from "forge-std/StdError.sol";
 
 contract LatestRoundData_Fuzz_Unit_Test is BaseTest {
-    function testFuzz_shouldRevert_LtEqZeroAnswer0(int256 answer0) external {
-        vm.assume(answer0 < 0);
+    modifier givenWhenDecimalsLtEq18() {
+        _;
+    }
+
+    function testFuzz_ShouldRevert_PoolBalanceDifferenceTooLarge(
+        uint256 token0PoolReserve,
+        uint256 token1PoolReserve
+    )
+        external
+        givenWhenDecimalsLtEq18
+    {
+        token0PoolReserve = bound(token0PoolReserve, 1, (type(uint256).max / 1e18) - 1);
+        token1PoolReserve = bound(token1PoolReserve, token0PoolReserve * 1e18 + 1, type(uint256).max);
+
+        // Mocks
+        setLatestRoundDataMocks(defaults.ANSWER0(), defaults.ANSWER1(), token0PoolReserve, token1PoolReserve);
+
+        vm.expectRevert();
+        oracle.latestRoundData();
+    }
+
+    modifier whenValidPoolBalances() {
+        _;
+    }
+
+    function testFuzz_shouldRevert_LtEqZeroAnswer0(int256 answer0)
+        external
+        givenWhenDecimalsLtEq18
+        whenValidPoolBalances
+    {
+        vm.assume(answer0 <= 0);
 
         setLatestRoundDataMocks(answer0, defaults.ANSWER1(), defaults.TOKEN0_BALANCE(), defaults.TOKEN1_BALANCE());
 
@@ -16,8 +45,12 @@ contract LatestRoundData_Fuzz_Unit_Test is BaseTest {
         oracle.latestRoundData();
     }
 
-    function testFuzz_shouldRevert_LtEqZeroAnswer1(int256 answer1) external {
-        vm.assume(answer1 < 0);
+    function testFuzz_shouldRevert_LtEqZeroAnswer1(int256 answer1)
+        external
+        givenWhenDecimalsLtEq18
+        whenValidPoolBalances
+    {
+        vm.assume(answer1 <= 0);
 
         setLatestRoundDataMocks(defaults.ANSWER0(), answer1, defaults.TOKEN0_BALANCE(), defaults.TOKEN1_BALANCE());
 

--- a/test/unit/latest-round-data/fuzz/LatestRoundData.t.sol
+++ b/test/unit/latest-round-data/fuzz/LatestRoundData.t.sol
@@ -134,7 +134,6 @@ contract LatestRoundData_Fuzz_Unit_Test is BaseTest {
     }
 
     function testFuzz_ArbitraryWeights_TooMuchToken1(
-        uint8 decimals,
         int256 answer0,
         int256 answer1,
         uint256 weight0,
@@ -203,7 +202,6 @@ contract LatestRoundData_Fuzz_Unit_Test is BaseTest {
     }
 
     function testFuzz_ArbitraryWeights_TooMuchToken0(
-        uint8 decimals,
         int256 answer0,
         int256 answer1,
         uint256 weight0,

--- a/test/utils/Calculations.sol
+++ b/test/utils/Calculations.sol
@@ -51,19 +51,20 @@ contract Calculations {
         int256 answer0,
         int256 answer1,
         uint256 token0Balance,
-        uint256 token1Balance
+        uint256 token1Balance,
+        uint256 lpSupply
     )
         internal
         pure
         returns (uint256)
     {
         if (feed0Decimals == feed1Decimals) {
-            return (token0Balance * uint256(answer0) + token1Balance * uint256(answer1)) / 1e18;
+            return (token0Balance * uint256(answer0) + token1Balance * uint256(answer1)) / lpSupply;
         } else {
             return (
                 token0Balance * uint256(answer0) * 10 ** (18 - feed0Decimals)
                     + token1Balance * uint256(answer1) * 10 ** (18 - feed1Decimals)
-            ) / 1e18;
+            ) / lpSupply;
         }
     }
 

--- a/test/utils/Calculations.sol
+++ b/test/utils/Calculations.sol
@@ -91,4 +91,17 @@ contract Calculations {
             return (adjustedAnswer1 * token1Balance * weight0) / (adjustedAnswer0 * (1e18 - weight0));
         }
     }
+
+    function calcBalanceFromTVL(
+        uint8 feedDecimals,
+        int256 answer,
+        uint256 valueLocked
+    )
+        internal
+        pure
+        returns (uint256)
+    {
+        uint256 adjustedAnswer = uint256(answer) * 10 ** (18 - feedDecimals);
+        return (valueLocked * 1e18) / adjustedAnswer;
+    }
 }

--- a/test/utils/Calculations.sol
+++ b/test/utils/Calculations.sol
@@ -66,4 +66,29 @@ contract Calculations {
             ) / 1e18;
         }
     }
+
+    /// @dev Helper function that calculates the pool token 0 balance given:
+    ///   - price feed answers
+    ///   - pool token 0 normalized weight
+    ///   - pool token 1 balance
+    function calcToken0FromToken1(
+        uint8 feed0Decimals,
+        uint8 feed1Decimals,
+        int256 answer0,
+        int256 answer1,
+        uint256 weight0,
+        uint256 token1Balance
+    )
+        internal
+        pure
+        returns (uint256)
+    {
+        if (feed0Decimals == feed1Decimals) {
+            return (uint256(answer1) * token1Balance * weight0) / (uint256(answer0) * (1e18 - weight0));
+        } else {
+            uint256 adjustedAnswer0 = uint256(answer0) * 10 ** (18 - feed0Decimals);
+            uint256 adjustedAnswer1 = uint256(answer1) * 10 ** (18 - feed1Decimals);
+            return (adjustedAnswer1 * token1Balance * weight0) / (adjustedAnswer0 * (1e18 - weight0));
+        }
+    }
 }

--- a/test/utils/Calculations.sol
+++ b/test/utils/Calculations.sol
@@ -44,4 +44,26 @@ contract Calculations {
             )
         );
     }
+
+    function calculateNaivePrice(
+        uint8 feed0Decimals,
+        uint8 feed1Decimals,
+        int256 answer0,
+        int256 answer1,
+        uint256 token0Balance,
+        uint256 token1Balance
+    )
+        internal
+        pure
+        returns (uint256)
+    {
+        if (feed0Decimals == feed1Decimals) {
+            return (token0Balance * uint256(answer0) + token1Balance * uint256(answer1)) / 1e18;
+        } else {
+            return (
+                token0Balance * uint256(answer0) * 10 ** (18 - feed0Decimals)
+                    + token1Balance * uint256(answer1) * 10 ** (18 - feed1Decimals)
+            ) / 1e18;
+        }
+    }
 }


### PR DESCRIPTION
### Parameters:
#### Pool
  - Weight ranges: 5-95% for token0
  - Pool TVL range: $5k to $5m in token 1 value
  - Price feeds: 8 decimals, price range $1-$1m for both tokens
  
#### Imbalancing 
  - When token 0 is the out token, keep the outflow fraction between 5-70% due to token1/token0 balance ratio constraints in calcToken0FromToken1.
  - When token 1 is the out token, 5-95% range is okay.

### Coverage:
- Balanced pool tests verify oracle price matches naive spot price
- Imbalanced pool tests verify oracle price < naive spot price

Open Questions:
- How to best capture and analyze the relationship between oracle and naive pricing across different imbalance scenarios?
  - The difference varies widely based on imbalance magnitude & pool weights
  - Current assertion checks direction (naive > oracle) but doesn't constrain the magnitude
  - Consider adding helpers to log/analyse these differences for better visibility into the behavior -- ffi + analysis scripts, perhaps.