### PR TITLE
test: Add unit and fuzz tests for TVL calculation

### DIFF
--- a/test/unit/calculate-tvl/calculateTVL.tree
+++ b/test/unit/calculate-tvl/calculateTVL.tree
@@ -1,0 +1,17 @@
+CalculateTVL.t.sol
+├── when the pool balance of token 1 is greater than the pool balance of token 0 multiplied by WAD
+│   └── it should revert
+└── when the pool balance of token 1 is less than, or equal to, the pool balance of token 0 multiplied by WAD
+    ├── when the pool balance of token 1 is zero
+    │   └── it should revert
+    └── when the pool balance of token 1 is positive
+        ├── when the pool invariant k calculation overflows
+        │   └── it should revert
+        └── when the pool invariant k does not overflow
+            ├── when the weight factor calculation overflows
+            │   └── it should revert
+            └── when the weight factor calculation does not overflow
+                ├── when the TVL calculation overflows
+                │   └── it should revert
+                └── when the TVL calculation does not overflow
+                    └── it should return the pool TVL with the same decimal basis as the input answers

--- a/test/unit/calculate-tvl/calculateTVL.tree
+++ b/test/unit/calculate-tvl/calculateTVL.tree
@@ -1,17 +1,20 @@
 CalculateTVL.t.sol
-├── when the pool balance of token 1 is greater than the pool balance of token 0 multiplied by WAD
+├── when the pool balance of token 0 is greater than the maximum 256 bit signed integer divided by WAD
 │   └── it should revert
-└── when the pool balance of token 1 is less than, or equal to, the pool balance of token 0 multiplied by WAD
-    ├── when the pool balance of token 1 is zero
+└── when the pool balance of token 0 is less than, or equal to, the maximum 256 bit signed integer divided by WAD
+    ├── when the pool balance of token 1 is less than, or equal to, zero
     │   └── it should revert
     └── when the pool balance of token 1 is positive
-        ├── when the pool invariant k calculation overflows
+        ├── when the pool balance of token 1 is greater than the pool balance of token 0 multiplied by WAD
         │   └── it should revert
-        └── when the pool invariant k does not overflow
-            ├── when the weight factor calculation overflows
+        └── when the pool balance of token 1 is less than, or equal to, the pool balance of token 0 multiplied by WAD
+            ├── when the wadMul operation in the pool invariant k calculation overflows
             │   └── it should revert
-            └── when the weight factor calculation does not overflow
-                ├── when the TVL calculation overflows
+            └── when the wadMul operation in the pool invariant k calculation does not overflow
+                ├── when at least one answer returned from the price feed is less than, or equal to, zero
                 │   └── it should revert
-                └── when the TVL calculation does not overflow
-                    └── it should return the pool TVL with the same decimal basis as the input answers
+                └── when both answers returned from the price feeds is greater than zero
+                    ├── when at least one wadMul operation in the TVL calculation overflows
+                    │   └── it should revert
+                    └── when no wadMul operation overflows in the TVL calculation
+                        └── it should return the pool TVL cast as an unsigned 256 bit integer

--- a/test/unit/calculate-tvl/concrete/CalculateTVL.t.sol
+++ b/test/unit/calculate-tvl/concrete/CalculateTVL.t.sol
@@ -64,4 +64,100 @@ contract CalculateTVL_Concrete_Unit_Test is BaseTest {
     modifier whenKDoesNotOverflow() {
         _;
     }
+
+    /* ------------------------------------------------------------ */
+    /*   # CALCULATE POOL TVL                                       */
+    /* ------------------------------------------------------------ */
+
+    // int256 pxComponent = wadPow(answer0, WEIGHT0);
+    // int256 pyComponent = wadPow(answer1, WEIGHT1);
+    // uint256 tvl = uint256(wadMul(wadMul(wadMul(k, pxComponent), pyComponent), weightFactor));
+
+    function test_ShouldRevert_TVL_AnswerZero() external {
+        vm.expectRevert("UNDEFINED");
+        wadPow(0, 0.5e18);
+    }
+
+    function test_ShouldRevert_TVL_AnswerNegative() external {
+        vm.expectRevert("UNDEFINED");
+        wadPow(-1, 0.5e18);
+    }
+
+    modifier whenAnswersPositive() {
+        _;
+    }
+
+    // In tvl calculation, there are 3 consecutive wadMul operations. To avoid overflow:
+    // Require: k * pxComponent * pyComponent * weightFactor <= type(int256).max
+    //
+    // The weightFactor is a maximum for a 50/50 pool, minimum for 98/2 pool.
+    // Maximum: weightFactor = 2e18
+    //
+    // For a given balance0 in a 50/50 balanced pool, changing the magnitude of balance1
+    // by an order of 2 changes the order of the k value in the same direction. Example:
+    // Let b0 = 1000e18 & b1 = 1e16: k = 3.16
+    // Now, let b1 = 1e18: k = 31.6
+
+    function test_ShouldRevert_TVL_WadMulsLeadToOverflow()
+        external
+        whenValidBalance0
+        whenValidBalance1
+        whenKDoesNotOverflow
+        whenAnswersPositive
+    {
+        int256 weight0 = 0.5e18; // 50/50 pool
+        int256 weightFactor = 2e18;
+
+        // k value
+        int256 balance0 = type(int160).max;
+        int256 balance1 = balance0 * 1e18;
+        int256 k = wadMul(wadPow(wadDiv(balance0, balance1), weight0), balance1);
+
+        // components
+        int256 answer0 = 1e24;
+        int256 answer1 = 2e18;
+        int256 pxComponent = wadPow(answer0, weight0);
+        int256 pyComponent = wadPow(answer1, 1e18 - weight0);
+
+        // tvl
+        vm.expectRevert();
+        uint256 tvl = uint256(wadMul(wadMul(wadMul(k, pxComponent), pyComponent), weightFactor));
+    }
+
+    function test_TVL_VeryHighAnswersAndHighFeedDecimals() external {
+        // Max value for: k * pxComponent * pyComponent
+        int256 weight0 = 0.5e18;
+        int256 weightFactor = 2e18; // max weight factor
+        int256 maxValueForKPxPy = type(int256).max / weightFactor; // has 58 decimals
+
+        // Both answers are high
+        // $10m expressed with 18 decimals
+        int256 answer = 1_000_000e18;
+        int256 pComponent = wadPow(answer, weight0); // pxComponent == pyComponent
+
+        // max k value
+        int256 maxK = maxValueForKPxPy / (pComponent ** 2);
+        assertLt(maxK, 1e18); // relatively low maximum k value
+    }
+
+    function test_TVL_LowAnswersAndLowFeedDecimals() external {
+        // Max value for: k * pxComponent * pyComponent
+        int256 weight0 = 0.5e18;
+        int256 weightFactor = 2e18; // max weight factor
+        int256 maxValueForKPxPy = type(int256).max / weightFactor; // has 58 decimals
+
+        // Both answers are relatively low
+        // $0.0000001 expressed with 8 decimals
+        int256 answer = 1;
+        int256 pComponent = wadPow(answer, weight0); // pxComponent == pyComponent
+
+        // max k value
+        int256 maxK = maxValueForKPxPy / (pComponent ** 2);
+        assertGt(maxK, 1e40); // relatively high maximum k value
+    }
+
+    // @todo potential to do some analysis on the 'allowed' variable space
+    // Given pool weights and underlying assets in an expected price range,
+    //   - what are acceptable balances?
+    //   - how sensitive is the configuration to underlying feed decimal changes?
 }

--- a/test/unit/calculate-tvl/concrete/CalculateTVL.t.sol
+++ b/test/unit/calculate-tvl/concrete/CalculateTVL.t.sol
@@ -124,7 +124,13 @@ contract CalculateTVL_Concrete_Unit_Test is BaseTest {
         uint256 tvl = uint256(wadMul(wadMul(wadMul(k, pxComponent), pyComponent), weightFactor));
     }
 
-    function test_TVL_VeryHighAnswersAndHighFeedDecimals() external {
+    function test_TVL_MaxKValue_VeryHighAnswersAndHighFeedDecimals()
+        external
+        whenValidBalance0
+        whenValidBalance1
+        whenKDoesNotOverflow
+        whenAnswersPositive
+    {
         // Max value for: k * pxComponent * pyComponent
         int256 weight0 = 0.5e18;
         int256 weightFactor = 2e18; // max weight factor
@@ -140,7 +146,13 @@ contract CalculateTVL_Concrete_Unit_Test is BaseTest {
         assertLt(maxK, 1e18); // relatively low maximum k value
     }
 
-    function test_TVL_LowAnswersAndLowFeedDecimals() external {
+    function test_TVL_MaxKValue_LowAnswersAndLowFeedDecimals()
+        external
+        whenValidBalance0
+        whenValidBalance1
+        whenKDoesNotOverflow
+        whenAnswersPositive
+    {
         // Max value for: k * pxComponent * pyComponent
         int256 weight0 = 0.5e18;
         int256 weightFactor = 2e18; // max weight factor

--- a/test/unit/calculate-tvl/concrete/CalculateTVL.t.sol
+++ b/test/unit/calculate-tvl/concrete/CalculateTVL.t.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.25;
+
+import { BaseTest } from "test/Base.t.sol";
+import { stdError } from "forge-std/StdError.sol";
+import { wadMul, wadDiv, wadPow } from "solmate/utils/SignedWadMath.sol";
+
+contract CalculateTVL_Concrete_Unit_Test is BaseTest {
+    /* ------------------------------------------------------------ */
+    /*   # POOL INVARIANT K CALCULATION                             */
+    /* ------------------------------------------------------------ */
+
+    // int256 k = wadMul(wadPow(wadDiv(balance0, balance1), WEIGHT0), balance1);
+
+    function test_ShouldRevert_InvariantK_Balance0TooLarge() external {
+        int256 balance0 = (type(int256).max / 1e18) + 1;
+        int256 balance1 = 3000e18;
+        vm.expectRevert();
+        wadDiv(balance0, balance1);
+    }
+
+    modifier whenValidBalance0() {
+        _;
+    }
+
+    function test_ShouldRevert_InvariantK_Balance1Zero() external whenValidBalance0 {
+        int256 balance0 = 1e18;
+        vm.expectRevert();
+        wadDiv(balance0, 0);
+    }
+
+    function test_ShouldRevert_InvariantK_Balance1Negative() external whenValidBalance0 {
+        int256 balance0 = 1e18;
+        int256 balance1 = -1;
+        int256 weight0 = 0.5e18;
+        vm.expectRevert();
+        wadPow(wadDiv(balance0, balance1), weight0);
+    }
+
+    function test_ShouldRevert_InvariantK_Balance1LargeRelativeBalance0() external whenValidBalance0 {
+        int256 balance0 = 1e18;
+        int256 balance1 = balance0 * 1e18 + 1;
+        int256 weight0 = int256(defaults.WEIGHT_50());
+        vm.expectRevert("UNDEFINED");
+        wadPow(wadDiv(balance0, balance1), weight0);
+    }
+
+    modifier whenValidBalance1() {
+        // Require 1 & 2
+        // 1. > 0
+        // 2. <= balance0 * 1e18
+        _;
+    }
+
+    function test_ShouldRevert_InvariantK_WadMulOverflows() external whenValidBalance0 whenValidBalance1 {
+        // Set max values
+        int256 balance0 = (type(int256).max / 1e18);
+        int256 balance1 = balance0 * 1e18;
+        int256 weight0 = 98e16;
+        vm.expectRevert();
+        wadMul(wadPow(wadDiv(balance0, balance1), weight0), balance1);
+    }
+
+    modifier whenKDoesNotOverflow() {
+        _;
+    }
+}

--- a/test/unit/calculate-tvl/fuzz/CalculateTVL.t.sol
+++ b/test/unit/calculate-tvl/fuzz/CalculateTVL.t.sol
@@ -36,4 +36,17 @@ contract CalculateTVL_Fuzz_Unit_Test is BaseTest {
         int256 a = wadDiv(balance0, balance1);
         assertGt(a, 0);
     }
+
+    /* ------------------------------------------------------------ */
+    /*   # WEIGHT FACTOR                                            */
+    /* ------------------------------------------------------------ */
+
+    // int256 weightFactor = wadPow(wadDiv(WEIGHT0, WEIGHT1), WEIGHT1) + wadPow(wadDiv(WEIGHT1, WEIGHT0), WEIGHT0);
+
+    function testFuzz_WeightFactor_ForValidPoolWeights(int256 weight0) external {
+        weight0 = bound(weight0, 2e16, 98e16); // only valid BCoWPool combinations
+        int256 weight1 = 1e18 - weight0;
+        int256 weightFactor = wadPow(wadDiv(weight0, weight1), weight1) + wadPow(wadDiv(weight1, weight0), weight0);
+        assertGt(weightFactor, 0);
+    }
 }

--- a/test/unit/calculate-tvl/fuzz/CalculateTVL.t.sol
+++ b/test/unit/calculate-tvl/fuzz/CalculateTVL.t.sol
@@ -49,4 +49,59 @@ contract CalculateTVL_Fuzz_Unit_Test is BaseTest {
         int256 weightFactor = wadPow(wadDiv(weight0, weight1), weight1) + wadPow(wadDiv(weight1, weight0), weight0);
         assertGt(weightFactor, 0);
     }
+
+    /* ------------------------------------------------------------ */
+    /*   # CALCULATE POOL TVL                                       */
+    /* ------------------------------------------------------------ */
+
+    // int256 pxComponent = wadPow(answer0, WEIGHT0);
+    // int256 pyComponent = wadPow(answer1, WEIGHT1);
+    // uint256 tvl = uint256(wadMul(wadMul(wadMul(k, pxComponent), pyComponent), weightFactor));
+
+    modifier whenKDoesNotOverflow() {
+        _;
+    }
+
+    modifier whenAnswersPositive() {
+        _;
+    }
+
+    function testFuzz_TVL_HighAnswersAndHighDecimals(
+        int256 balance0,
+        int256 balance1,
+        int256 answer0,
+        int256 answer1
+    )
+        external
+        whenValidBalance0
+        whenValidBalance1
+        whenKDoesNotOverflow
+        whenAnswersPositive
+    { }
+
+    function testFuzz_TVL_LowAnswersAndLowDecimals(
+        int256 balance0,
+        int256 balance1,
+        int256 answer0,
+        int256 answer1
+    )
+        external
+        whenValidBalance0
+        whenValidBalance1
+        whenKDoesNotOverflow
+        whenAnswersPositive
+    { }
+
+    function testFuzz_TVL_UnderlyingFeedDecimalsIncreased(
+        int256 balance0,
+        int256 balance1,
+        int256 answer0,
+        int256 answer1
+    )
+        external
+        whenValidBalance0
+        whenValidBalance1
+        whenKDoesNotOverflow
+        whenAnswersPositive
+    { }
 }

--- a/test/unit/calculate-tvl/fuzz/CalculateTVL.t.sol
+++ b/test/unit/calculate-tvl/fuzz/CalculateTVL.t.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.25;
+
+import { BaseTest } from "test/Base.t.sol";
+import { stdError } from "forge-std/StdError.sol";
+import { wadMul, wadDiv, wadPow } from "solmate/utils/SignedWadMath.sol";
+
+contract CalculateTVL_Fuzz_Unit_Test is BaseTest {
+    /* ------------------------------------------------------------ */
+    /*   # POOL INVARIANT K CALCULATION                             */
+    /* ------------------------------------------------------------ */
+
+    // int256 k = wadMul(wadPow(wadDiv(balance0, balance1), WEIGHT0), balance1);
+
+    function testFuzz_Token0BalanceTooLarge(int256 balance0) external {
+        balance0 = bound(balance0, type(int256).max / 1e18 + 1, type(int256).max);
+        int256 balance1 = 3000e18;
+        vm.expectRevert();
+        wadDiv(balance0, balance1);
+    }
+
+    modifier whenValidBalance0() {
+        _;
+    }
+
+    modifier whenValidBalance1() {
+        // Require 1 & 2
+        // 1. > 0
+        // 2. <= balance0 * 1e18
+        _;
+    }
+
+    function testFuzz_InvariantK(int256 balance0, int256 balance1) external whenValidBalance0 whenValidBalance1 {
+        balance0 = bound(balance0, 1, type(int256).max / 1e18);
+        balance1 = bound(balance1, 1, balance0 * 1e18);
+        int256 a = wadDiv(balance0, balance1);
+        assertGt(a, 0);
+    }
+}


### PR DESCRIPTION
Break down TVL calculation testing into three components:
- Pool invariant K calculation
- Weight factor computation
- Final TVL calculation

Each component is tested with both concrete unit tests for edge cases and property-based fuzz tests to verify behavior across valid input ranges.