### PR TITLE
fix: return correct oracle decimals based on price feed configuration

### DIFF
--- a/src/LPOracle.sol
+++ b/src/LPOracle.sol
@@ -71,8 +71,9 @@ contract LPOracle is AggregatorV3Interface {
     |*----------------------------------------------------------*/
 
     /// @notice Returns the number of decimals used.
-    function decimals() external pure returns (uint8) {
-        return 8;
+    function decimals() external view returns (uint8) {
+        uint8 feed0Decimals = FEED0.decimals();
+        return feed0Decimals == FEED1.decimals() ? feed0Decimals : 18;
     }
 
     /// @notice Returns the description of the LP token pricing oracle.


### PR DESCRIPTION
Current oracle `decimals` implementation is hard-coded to return 8. This is inaccurate. 

- When price feed decimals are the same, the oracle decimals should be the same. 
- When price feed decimals are different, their answers are scaled to 18 so the oracle decimals should be 18.