### PR TITLE
test: add generic fork tests

### DIFF
--- a/test/fork/Fork.t.sol
+++ b/test/fork/Fork.t.sol
@@ -21,6 +21,14 @@ contract ForkTest is Addresses, BaseTest {
     AggregatorV3Interface internal immutable FORK_FEED0;
     AggregatorV3Interface internal immutable FORK_FEED1;
 
+    uint256 internal INITIAL_POOL_TOKEN0_BALANCE;
+    uint256 internal INITIAL_POOL_TOKEN1_BALANCE;
+    uint256 internal INITIAL_POOL_LP_SUPPLY;
+    int256 internal INITIAL_FEED0_ANSWER;
+    int256 internal INITIAL_FEED1_ANSWER;
+    uint8 internal FEED0_DECIMALS;
+    uint8 internal FEED1_DECIMALS;
+
     constructor(address _token0, address _token1) {
         FORK_TOKEN0 = IERC20(_token0);
         FORK_TOKEN1 = IERC20(_token1);
@@ -43,6 +51,18 @@ contract ForkTest is Addresses, BaseTest {
 
         // Label contracts.
         labelContracts();
+
+        // Cache variables
+        INITIAL_POOL_TOKEN0_BALANCE = FORK_TOKEN0.balanceOf(address(FORK_POOL));
+        INITIAL_POOL_TOKEN1_BALANCE = FORK_TOKEN1.balanceOf(address(FORK_POOL));
+        INITIAL_POOL_LP_SUPPLY = FORK_POOL.totalSupply();
+
+        (, INITIAL_FEED0_ANSWER,,,) = FORK_FEED0.latestRoundData();
+
+        (, INITIAL_FEED1_ANSWER,,,) = FORK_FEED1.latestRoundData();
+
+        FEED0_DECIMALS = FORK_FEED0.decimals();
+        FEED1_DECIMALS = FORK_FEED1.decimals();
     }
 
     function labelContracts() internal {

--- a/test/fork/Fork.t.sol
+++ b/test/fork/Fork.t.sol
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.8.25 < 0.9.0;
 
-import { Test } from "forge-std/Test.sol";
+import { BaseTest } from "test/Base.t.sol";
 import { Addresses } from "test/utils/Addresses.sol";
-import { Assertions } from "test/utils/Assertions.sol";
 
 import { LPOracle } from "src/LPOracle.sol";
 import { LPOracleFactory } from "src/LPOracleFactory.sol";
@@ -12,8 +11,8 @@ import { ICOWAMMPoolHelper } from "@cow-amm/interfaces/ICOWAMMPoolHelper.sol";
 import { AggregatorV3Interface } from "@cow-amm/interfaces/AggregatorV3Interface.sol";
 import { IERC20 } from "cowprotocol/contracts/interfaces/IERC20.sol";
 
-contract ForkTest is Addresses, Assertions, Test {
-    LPOracle internal oracle;
+contract ForkTest is Addresses, BaseTest {
+    LPOracle internal lpOracle;
     LPOracleFactory internal factory;
 
     IERC20 internal immutable FORK_POOL;
@@ -33,14 +32,14 @@ contract ForkTest is Addresses, Assertions, Test {
         FORK_FEED1 = AggregatorV3Interface(_feed1);
     }
 
-    function setUp() public virtual {
+    function setUp() public virtual override {
         // Fork Ethereum Mainnet at a specific block number.
         // Be careful with setting block numbers at times when the pool doesn't exist.
         vm.createSelectFork({ blockNumber: 21_422_754, urlOrAlias: "mainnet" });
 
         // Deploy contracts to the fork.
         factory = new LPOracleFactory();
-        oracle = LPOracle(factory.deployOracle(address(FORK_POOL), address(FORK_FEED0), address(FORK_FEED1)));
+        lpOracle = LPOracle(factory.deployOracle(address(FORK_POOL), address(FORK_FEED0), address(FORK_FEED1)));
 
         // Label contracts.
         labelContracts();
@@ -48,7 +47,7 @@ contract ForkTest is Addresses, Assertions, Test {
 
     function labelContracts() internal {
         vm.label(address(factory), "FACTORY");
-        vm.label(address(oracle), "ORACLE");
+        vm.label(address(lpOracle), "ORACLE");
         vm.label(address(FORK_POOL), "POOL");
         vm.label(address(FORK_TOKEN0), "TOKEN0");
         vm.label(address(FORK_TOKEN1), "TOKEN1");

--- a/test/fork/LPOracle.t.sol
+++ b/test/fork/LPOracle.t.sol
@@ -2,6 +2,7 @@
 pragma solidity >=0.8.25 < 0.9.0;
 
 import { ForkTest } from "test/fork/Fork.t.sol";
+import { stdMath } from "forge-std/StdMath.sol";
 
 contract LPOracle_Fork_Test is ForkTest {
     constructor(address _token0, address _token1) ForkTest(_token0, _token1) { }
@@ -21,5 +22,60 @@ contract LPOracle_Fork_Test is ForkTest {
     function test_Descriptor() external view {
         string memory expectedDescription = string.concat(FORK_POOL.name(), " LP Token / USD");
         assertEq(lpOracle.description(), expectedDescription, "description");
+    }
+
+    function test_LatestRoundData_ManipulatePoolBalances_LargeAmountToken1Out() external {
+        // Initial pool token balances
+        uint256 token0Balance = FORK_TOKEN0.balanceOf(address(FORK_POOL));
+        uint256 token1Balance = FORK_TOKEN1.balanceOf(address(FORK_POOL));
+
+        // Get underlying price feed answers
+        (, int256 answer0,,,) = FORK_FEED0.latestRoundData();
+        (, int256 answer1,,,) = FORK_FEED1.latestRoundData();
+
+        // Get other inputs for calculateNaivePrice
+        uint8 feed0Decimals = FORK_FEED0.decimals();
+        uint8 feed1Decimals = FORK_FEED1.decimals();
+        uint256 lpSupply = FORK_POOL.totalSupply();
+
+        // Calculate naive price before manipulation
+        uint256 naivePriceBefore =
+            calculateNaivePrice(feed0Decimals, feed1Decimals, answer0, answer1, token0Balance, token1Balance, lpSupply);
+
+        // Get the current LPOracle answer
+        (, int256 answer,,,) = lpOracle.latestRoundData();
+
+        // Assert that the pool is in a relatively balanced state: naivePrice ≈ LPOracle answer
+        assertApproxEqRel(uint256(answer), naivePriceBefore, 1e15); // within 0.1%
+
+        // Calculate token amounts out and in
+        uint256 token1AmountOut = (9000 * token1Balance) / 1e4; // 90% token 1 out
+        uint256 token0AmountIn = calcInGivenOutSignedWadMath(
+            token0Balance, uint256(lpOracle.WEIGHT0()), token1Balance, uint256(lpOracle.WEIGHT1()), token1AmountOut
+        );
+
+        // Mock the new balances
+        mock_token_balanceOf(FORK_TOKEN0, FORK_POOL, token0Balance + token0AmountIn);
+        mock_token_balanceOf(FORK_TOKEN1, FORK_POOL, token1Balance - token1AmountOut);
+
+        // Calculate the naive price
+        uint256 naivePriceAfter = calculateNaivePrice(
+            feed0Decimals,
+            feed1Decimals,
+            answer0,
+            answer1,
+            token0Balance + token0AmountIn,
+            token1Balance - token1AmountOut,
+            lpSupply
+        );
+
+        // Retrieve the LPOracle answer
+        (, answer,,,) = lpOracle.latestRoundData();
+
+        // Assertions
+        // The LPOracle answer after manipulation is within 0.1% price before manipulation
+        assertApproxEqRel(uint256(answer), naivePriceBefore, 1e15);
+        // The naive price after manipulation is > 200% more than the LPOracle price
+        assertGt(stdMath.percentDelta(naivePriceAfter, uint256(answer)), 2e18);
     }
 }

--- a/test/fork/LPOracle.t.sol
+++ b/test/fork/LPOracle.t.sol
@@ -41,6 +41,11 @@ contract LPOracle_Fork_Test is ForkTest {
 
         // Assert that the pool is in a relatively balanced state: naivePrice ≈ LPOracle answer
         assertApproxEqRel(uint256(answer), naivePriceBefore, 1e15); // within 0.1%
+        assertApproxEqRel(
+            uint256(INITIAL_FEED0_ANSWER) * INITIAL_POOL_TOKEN0_BALANCE,
+            uint256(INITIAL_FEED1_ANSWER) * INITIAL_POOL_TOKEN1_BALANCE,
+            1e16
+        ); // within 1%
 
         // Calculate token amounts out and in
         uint256 token1AmountOut = (9000 * INITIAL_POOL_TOKEN1_BALANCE) / 1e4; // 90% token 1 out
@@ -64,6 +69,64 @@ contract LPOracle_Fork_Test is ForkTest {
             INITIAL_FEED1_ANSWER,
             INITIAL_POOL_TOKEN0_BALANCE + token0AmountIn,
             INITIAL_POOL_TOKEN1_BALANCE - token1AmountOut,
+            INITIAL_POOL_LP_SUPPLY
+        );
+
+        // Retrieve the LPOracle answer
+        (, answer,,,) = lpOracle.latestRoundData();
+
+        // Assertions
+        // The LPOracle answer after manipulation is within 0.1% price before manipulation
+        assertApproxEqRel(uint256(answer), naivePriceBefore, 1e15);
+        // The naive price after manipulation is > 200% more than the LPOracle price
+        assertGt(stdMath.percentDelta(naivePriceAfter, uint256(answer)), 2e18);
+    }
+
+    function test_LatestRoundData_ManipulatePoolBalances_LargeAmountToken0Out() external {
+        // Calculate naive price before manipulation
+        uint256 naivePriceBefore = calculateNaivePrice(
+            FEED0_DECIMALS,
+            FEED1_DECIMALS,
+            INITIAL_FEED0_ANSWER,
+            INITIAL_FEED1_ANSWER,
+            INITIAL_POOL_TOKEN0_BALANCE,
+            INITIAL_POOL_TOKEN1_BALANCE,
+            INITIAL_POOL_LP_SUPPLY
+        );
+
+        // Get the current LPOracle answer
+        (, int256 answer,,,) = lpOracle.latestRoundData();
+
+        // Assert that the pool is in a relatively balanced state: naivePrice ≈ LPOracle answer
+        assertApproxEqRel(uint256(answer), naivePriceBefore, 1e15); // within 0.1%
+        assertApproxEqRel(
+            uint256(INITIAL_FEED0_ANSWER) * INITIAL_POOL_TOKEN0_BALANCE,
+            uint256(INITIAL_FEED1_ANSWER) * INITIAL_POOL_TOKEN1_BALANCE,
+            1e16
+        ); // within 1%
+
+        // Calculate token amounts out and in
+        uint256 token0AmountOut = (9000 * INITIAL_POOL_TOKEN0_BALANCE) / 1e4; // 90% token 0 out
+        uint256 token1AmountIn = calcInGivenOutSignedWadMath(
+            INITIAL_POOL_TOKEN1_BALANCE,
+            uint256(lpOracle.WEIGHT1()),
+            INITIAL_POOL_TOKEN0_BALANCE,
+            uint256(lpOracle.WEIGHT0()),
+            token0AmountOut
+        );
+
+        // Mock the new balances
+        mock_token_balanceOf(FORK_TOKEN0, FORK_POOL, INITIAL_POOL_TOKEN0_BALANCE - token0AmountOut);
+        mock_token_balanceOf(FORK_TOKEN1, FORK_POOL, INITIAL_POOL_TOKEN1_BALANCE + token1AmountIn);
+
+        // Calculate the naive price
+        uint256 naivePriceAfter = calculateNaivePrice(
+            FEED0_DECIMALS,
+            FEED1_DECIMALS,
+            INITIAL_FEED0_ANSWER,
+            INITIAL_FEED1_ANSWER,
+            INITIAL_POOL_TOKEN0_BALANCE - token0AmountOut,
+            INITIAL_POOL_TOKEN1_BALANCE + token1AmountIn,
             INITIAL_POOL_LP_SUPPLY
         );
 

--- a/test/fork/LPOracle.t.sol
+++ b/test/fork/LPOracle.t.sol
@@ -8,6 +8,6 @@ contract LPOracle_Fork_Test is ForkTest {
 
     function test_Descriptor() external view {
         string memory expectedDescription = string.concat(FORK_POOL.name(), " LP Token / USD");
-        assertEq(oracle.description(), expectedDescription, "description");
+        assertEq(lpOracle.description(), expectedDescription, "description");
     }
 }

--- a/test/fork/LPOracle.t.sol
+++ b/test/fork/LPOracle.t.sol
@@ -6,6 +6,18 @@ import { ForkTest } from "test/fork/Fork.t.sol";
 contract LPOracle_Fork_Test is ForkTest {
     constructor(address _token0, address _token1) ForkTest(_token0, _token1) { }
 
+    function test_Decimals() external view {
+        uint8 feed0Decimals = FORK_FEED0.decimals();
+        uint8 feed1Decimals = FORK_FEED1.decimals();
+        uint8 oracleDecimals = lpOracle.decimals();
+
+        if (feed0Decimals == feed1Decimals) {
+            assertEq(oracleDecimals, feed0Decimals);
+        } else {
+            assertEq(oracleDecimals, 18);
+        }
+    }
+
     function test_Descriptor() external view {
         string memory expectedDescription = string.concat(FORK_POOL.name(), " LP Token / USD");
         assertEq(lpOracle.description(), expectedDescription, "description");

--- a/test/fork/LPOracle.t.sol
+++ b/test/fork/LPOracle.t.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.8.25 < 0.9.0;
 
 import { ForkTest } from "test/fork/Fork.t.sol";
 
-contract Description_Fork_Test is ForkTest {
+contract LPOracle_Fork_Test is ForkTest {
     constructor(address _token0, address _token1) ForkTest(_token0, _token1) { }
 
     function test_Descriptor() external view {

--- a/test/fork/pools/WETH50UNI50.t.sol
+++ b/test/fork/pools/WETH50UNI50.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.8.25 < 0.9.0;
 
-import { Description_Fork_Test } from "test/fork/Description.t.sol";
+import { LPOracle_Fork_Test } from "test/fork/LPOracle.t.sol";
 import { Addresses } from "test/utils/Addresses.sol";
 
-contract WETH50UNI50_Description_Fork_Test is Description_Fork_Test(Addresses.WETH, Addresses.UNI) { }
+contract WETH50UNI50_Fork_Test is LPOracle_Fork_Test(Addresses.WETH, Addresses.UNI) { }

--- a/test/utils/Utils.sol
+++ b/test/utils/Utils.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.25 < 0.9.0;
 
 import { Test } from "forge-std/Test.sol";
 import { OrderParams } from "test/utils/Types.sol";
+import { IERC20 } from "cowprotocol/contracts/interfaces/IERC20.sol";
 
 contract Utils is Test {
     /*----------------------------------------------------------*|
@@ -38,6 +39,10 @@ contract Utils is Test {
     /// @dev Helper to mock token pool balances.
     function mock_token_balanceOf(address token, address pool, uint256 balance) internal {
         vm.mockCall(token, abi.encodeWithSignature("balanceOf(address)", pool), abi.encode(balance));
+    }
+
+    function mock_token_balanceOf(IERC20 token, IERC20 pool, uint256 balance) internal {
+        vm.mockCall(address(token), abi.encodeWithSignature("balanceOf(address)", address(pool)), abi.encode(balance));
     }
 
     /*----------------------------------------------------------*|


### PR DESCRIPTION
This PR adds a generic fork test infrastructure that can be inherited by any pool-specific tests:

- Add `BaseTest` inheritance for fork tests to share common utilities
- Add generic pool balance manipulation tests
  - Test token0 outflow scenario (90% removal)
  - Test token1 outflow scenario (90% removal)
  - Verify oracle price remains stable while naive price deviates >200%

- Improve test infrastructure
  - Add IERC20-compatible mock utility function
  - Cache initial pool state in storage to avoid stack-too-deep errors
  - Add verification that pool is initially balanced (within 1% tolerance)

These tests can now serve as a base for testing any pool implementation with our oracle system.

Looking for feedback on additional test cases we should add to this generic test suite.