### PR TITLE
fix: normalize token decimals to 18 in TVL calculation

### DIFF
--- a/src/LPOracle.sol
+++ b/src/LPOracle.sol
@@ -155,8 +155,8 @@ contract LPOracle is AggregatorV3Interface {
     /// @param answer1 Price feed answer for token 1.
     function _calculateTVL(int256 answer0, int256 answer1) internal view returns (uint256 tvl) {
         /* Get pool k value */
-        int256 balance0 = int256(TOKEN0.balanceOf(POOL));
-        int256 balance1 = int256(TOKEN1.balanceOf(POOL));
+        int256 balance0 = int256(TOKEN0.balanceOf(POOL) * 10 ** (18 - TOKEN0_DECIMALS));
+        int256 balance1 = int256(TOKEN1.balanceOf(POOL) * 10 ** (18 - TOKEN1_DECIMALS));
         int256 k = wadMul(wadPow(wadDiv(balance0, balance1), WEIGHT0), balance1);
 
         /* Get weight factor */

--- a/test/unit/calculate-tvl/calculateTVL.tree
+++ b/test/unit/calculate-tvl/calculateTVL.tree
@@ -18,3 +18,5 @@ CalculateTVL.t.sol
                     │   └── it should revert
                     └── when no wadMul operation overflows in the TVL calculation
                         └── it should return the pool TVL cast as an unsigned 256 bit integer
+                        └── it should return expected TVL when both token decimals are the same
+                        └── it should return expected TVL when both token decimals are different

--- a/test/unit/calculate-tvl/calculateTVL.tree
+++ b/test/unit/calculate-tvl/calculateTVL.tree
@@ -1,22 +1,23 @@
 CalculateTVL.t.sol
-├── when the pool balance of token 0 is greater than the maximum 256 bit signed integer divided by WAD
+├── when the token decimals for a pool token is greater than 18
 │   └── it should revert
-└── when the pool balance of token 0 is less than, or equal to, the maximum 256 bit signed integer divided by WAD
-    ├── when the pool balance of token 1 is less than, or equal to, zero
+└── when the token decimals for a pool token is less than, or equal to 18
+    ├── when the pool balance of token 0 is greater than the maximum 256 bit signed integer divided by WAD
     │   └── it should revert
-    └── when the pool balance of token 1 is positive
-        ├── when the pool balance of token 1 is greater than the pool balance of token 0 multiplied by WAD
+    └── when the pool balance of token 0 is less than, or equal to, the maximum 256 bit signed integer divided by WAD
+        ├── when the pool balance of token 1 is less than, or equal to, zero
         │   └── it should revert
-        └── when the pool balance of token 1 is less than, or equal to, the pool balance of token 0 multiplied by WAD
-            ├── when the wadMul operation in the pool invariant k calculation overflows
+        └── when the pool balance of token 1 is positive
+            ├── when the pool balance of token 1 is greater than the pool balance of token 0 multiplied by WAD
             │   └── it should revert
-            └── when the wadMul operation in the pool invariant k calculation does not overflow
-                ├── when at least one answer returned from the price feed is less than, or equal to, zero
+            └── when the pool balance of token 1 is less than, or equal to, the pool balance of token 0 multiplied by WAD
+                ├── when the wadMul operation in the pool invariant k calculation overflows
                 │   └── it should revert
-                └── when both answers returned from the price feeds is greater than zero
-                    ├── when at least one wadMul operation in the TVL calculation overflows
+                └── when the wadMul operation in the pool invariant k calculation does not overflow
+                    ├── when at least one answer returned from the price feed is less than, or equal to, zero
                     │   └── it should revert
-                    └── when no wadMul operation overflows in the TVL calculation
-                        └── it should return the pool TVL cast as an unsigned 256 bit integer
-                        └── it should return expected TVL when both token decimals are the same
-                        └── it should return expected TVL when both token decimals are different
+                    └── when both answers returned from the price feeds is greater than zero
+                        ├── when at least one wadMul operation in the TVL calculation overflows
+                        │   └── it should revert
+                        └── when no wadMul operation overflows in the TVL calculation
+                            └── it should return the pool TVL with the same decimal basis as the input answers

--- a/test/unit/calculate-tvl/concrete/CalculateTVL.t.sol
+++ b/test/unit/calculate-tvl/concrete/CalculateTVL.t.sol
@@ -126,6 +126,7 @@ contract CalculateTVL_Concrete_Unit_Test is BaseTest {
 
     function test_TVL_MaxKValue_VeryHighAnswersAndHighFeedDecimals()
         external
+        pure
         whenValidBalance0
         whenValidBalance1
         whenKDoesNotOverflow
@@ -148,6 +149,7 @@ contract CalculateTVL_Concrete_Unit_Test is BaseTest {
 
     function test_TVL_MaxKValue_LowAnswersAndLowFeedDecimals()
         external
+        pure
         whenValidBalance0
         whenValidBalance1
         whenKDoesNotOverflow
@@ -168,6 +170,37 @@ contract CalculateTVL_Concrete_Unit_Test is BaseTest {
         assertGt(maxK, 1e40); // relatively high maximum k value
     }
 
+    function test_calculateTVL_SameDecimalTokens()
+        external
+        whenValidBalance0
+        whenValidBalance1
+        whenKDoesNotOverflow
+        whenAnswersPositive
+    {
+        int256 wethUsdPrice = 3000;
+        (int256 price0, int256 price1) = (wethUsdPrice * 1e8, 1e8);
+        // Balanced Pool with
+        setTokenBalances(defaults.TOKEN0_BALANCE(), defaults.TOKEN1_BALANCE());
+
+        uint256 tvl = oracle.exposed_calculateTVL(price0, price1);
+        assertApproxEqAbs(tvl, (2 * uint256(wethUsdPrice)) * 1e8, 2);
+    }
+
+    function test_calculateTVL_DifferentDecimalTokens()
+        external
+        whenValidBalance0
+        whenValidBalance1
+        whenKDoesNotOverflow
+        whenAnswersPositive
+    {
+        int256 wethUsdPrice = 3000;
+        (int256 price0, int256 price1) = (wethUsdPrice * 1e8, 1e8);
+        reinitOracle(18, 6);
+        setTokenBalances(1e18, uint256(wethUsdPrice) * 1e6);
+
+        uint256 tvl = oracle.exposed_calculateTVL(price0, price1);
+        assertApproxEqAbs(tvl, (2 * uint256(wethUsdPrice)) * 1e8, 2);
+    }
     // @todo potential to do some analysis on the 'allowed' variable space
     // Given pool weights and underlying assets in an expected price range,
     //   - what are acceptable balances?

--- a/test/unit/calculate-tvl/concrete/CalculateTVL.t.sol
+++ b/test/unit/calculate-tvl/concrete/CalculateTVL.t.sol
@@ -170,39 +170,52 @@ contract CalculateTVL_Concrete_Unit_Test is BaseTest {
         assertGt(maxK, 1e40); // relatively high maximum k value
     }
 
-    function test_calculateTVL_SameDecimalTokens()
+    /* ------------------------------------------------------------ */
+    /*   # ORACLE: _calculateTVL                                    */
+    /* ------------------------------------------------------------ */
+
+    function test_CalculateTVL_SameDecimalTokens()
         external
         whenValidBalance0
         whenValidBalance1
         whenKDoesNotOverflow
         whenAnswersPositive
     {
-        int256 wethUsdPrice = 3000;
-        (int256 price0, int256 price1) = (wethUsdPrice * 1e8, 1e8);
-        // Balanced Pool with
+        // Setup: answers
+        int256 answer0Base = 3000;
+        int256 answer1Base = 1;
+        (int256 answer0, int256 answer1) = (answer0Base * 1e8, answer1Base * 1e8);
+
+        // Mock token balances for the balanced 50/50 pool
         setTokenBalances(defaults.TOKEN0_BALANCE(), defaults.TOKEN1_BALANCE());
 
-        uint256 tvl = oracle.exposed_calculateTVL(price0, price1);
-        assertApproxEqAbs(tvl, (2 * uint256(wethUsdPrice)) * 1e8, 2);
+        // Calculate TVL
+        uint256 tvl = oracle.exposed_calculateTVL(answer0, answer1);
+
+        // Assertions
+        assertApproxEqAbs(tvl, (2 * uint256(answer0Base)) * 1e8, 2);
     }
 
-    function test_calculateTVL_DifferentDecimalTokens()
+    function test_CalculateTVL_DifferentDecimalTokens()
         external
         whenValidBalance0
         whenValidBalance1
         whenKDoesNotOverflow
         whenAnswersPositive
     {
-        int256 wethUsdPrice = 3000;
-        (int256 price0, int256 price1) = (wethUsdPrice * 1e8, 1e8);
-        reinitOracle(18, 6);
-        setTokenBalances(1e18, uint256(wethUsdPrice) * 1e6);
+        // Setup: answers
+        int256 answer0Base = 3000;
+        int256 answer1Base = 1;
+        (int256 answer0, int256 answer1) = (answer0Base * 1e8, answer1Base * 1e8);
 
-        uint256 tvl = oracle.exposed_calculateTVL(price0, price1);
-        assertApproxEqAbs(tvl, (2 * uint256(wethUsdPrice)) * 1e8, 2);
+        // Mocks
+        reinitOracle(18, 6);
+        setTokenBalances(1e18, uint256(answer0Base) * 1e6); // 1 unit token 0, 3000 units token 1
+
+        // Calculate TVL
+        uint256 tvl = oracle.exposed_calculateTVL(answer0, answer1);
+
+        // Assertions
+        assertApproxEqAbs(tvl, (2 * uint256(answer0Base)) * 1e8, 2);
     }
-    // @todo potential to do some analysis on the 'allowed' variable space
-    // Given pool weights and underlying assets in an expected price range,
-    //   - what are acceptable balances?
-    //   - how sensitive is the configuration to underlying feed decimal changes?
 }

--- a/test/unit/calculate-tvl/concrete/CalculateTVL.t.sol
+++ b/test/unit/calculate-tvl/concrete/CalculateTVL.t.sol
@@ -174,8 +174,21 @@ contract CalculateTVL_Concrete_Unit_Test is BaseTest {
     /*   # ORACLE: _calculateTVL                                    */
     /* ------------------------------------------------------------ */
 
+    function test_ShouldRevert_TokenDecimalsGt18() external {
+        reinitOracle(19, 6);
+        setTokenBalances(1e19, 1e6);
+
+        vm.expectRevert(stdError.arithmeticError);
+        oracle.exposed_calculateTVL(1e8, 1e8);
+    }
+
+    modifier whenTokenDecimalsLtEq18() {
+        _;
+    }
+
     function test_CalculateTVL_SameDecimalTokens()
         external
+        whenTokenDecimalsLtEq18
         whenValidBalance0
         whenValidBalance1
         whenKDoesNotOverflow
@@ -198,6 +211,7 @@ contract CalculateTVL_Concrete_Unit_Test is BaseTest {
 
     function test_CalculateTVL_DifferentDecimalTokens()
         external
+        whenTokenDecimalsLtEq18
         whenValidBalance0
         whenValidBalance1
         whenKDoesNotOverflow


### PR DESCRIPTION
The `_calculateTVL` function was unable to handle underlying tokens with differing decimals. Added decimal normalization to 18 decimals in the `balanceOf` lines.