### PR TITLE
chore: cleanup unused imports

### DIFF
--- a/test/Base.t.sol
+++ b/test/Base.t.sol
@@ -6,7 +6,7 @@ import { ExposedLPOracle } from "test/harness/ExposedLPOracle.sol";
 import { Assertions } from "test/utils/Assertions.sol";
 import { Calculations } from "test/utils/Calculations.sol";
 import { Defaults } from "test/utils/Defaults.sol";
-import { Mocks, OrderParams, TokenParams, FeedParams } from "test/utils/Types.sol";
+import { Mocks, FeedParams } from "test/utils/Types.sol";
 import { Utils } from "test/utils/Utils.sol";
 
 contract BaseTest is Assertions, Calculations, Utils {

--- a/test/fork/Fork.t.sol
+++ b/test/fork/Fork.t.sol
@@ -7,7 +7,6 @@ import { Addresses } from "test/utils/Addresses.sol";
 import { LPOracle } from "src/LPOracle.sol";
 import { LPOracleFactory } from "src/LPOracleFactory.sol";
 
-import { ICOWAMMPoolHelper } from "@cow-amm/interfaces/ICOWAMMPoolHelper.sol";
 import { AggregatorV3Interface } from "@cow-amm/interfaces/AggregatorV3Interface.sol";
 import { IERC20 } from "cowprotocol/contracts/interfaces/IERC20.sol";
 

--- a/test/harness/ExposedLPOracle.sol
+++ b/test/harness/ExposedLPOracle.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.25;
 
 import { LPOracle } from "src/LPOracle.sol";
-import { GPv2Order } from "cowprotocol/contracts/libraries/GPv2Order.sol";
 
 contract ExposedLPOracle is LPOracle {
     constructor(address _pool, address _feed0, address _feed1) LPOracle(_pool, _feed0, _feed1) { }

--- a/test/integration/Integration.t.sol
+++ b/test/integration/Integration.t.sol
@@ -39,7 +39,7 @@ contract IntegrationTest is Addresses, BaseTest {
     IPool internal pool;
     IPoolConfigurator internal poolConfigurator;
     IAaveOracle internal aaveOracle;
-    IPoolDataProvider poolDataProvider;
+    IPoolDataProvider internal poolDataProvider;
 
     // Pool admin
     address internal constant admin = 0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A;

--- a/test/unit/calculate-tvl/concrete/CalculateTVL.t.sol
+++ b/test/unit/calculate-tvl/concrete/CalculateTVL.t.sol
@@ -121,7 +121,7 @@ contract CalculateTVL_Concrete_Unit_Test is BaseTest {
 
         // tvl
         vm.expectRevert();
-        uint256 tvl = uint256(wadMul(wadMul(wadMul(k, pxComponent), pyComponent), weightFactor));
+        uint256(wadMul(wadMul(wadMul(k, pxComponent), pyComponent), weightFactor));
     }
 
     function test_TVL_MaxKValue_VeryHighAnswersAndHighFeedDecimals()

--- a/test/unit/calculate-tvl/fuzz/CalculateTVL.t.sol
+++ b/test/unit/calculate-tvl/fuzz/CalculateTVL.t.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.25;
 
 import { BaseTest } from "test/Base.t.sol";
-import { stdError } from "forge-std/StdError.sol";
 import { wadMul, wadDiv, wadPow } from "solmate/utils/SignedWadMath.sol";
 
 contract CalculateTVL_Fuzz_Unit_Test is BaseTest {

--- a/test/unit/latest-round-data/concrete/LatestRoundData.t.sol
+++ b/test/unit/latest-round-data/concrete/LatestRoundData.t.sol
@@ -2,8 +2,6 @@
 pragma solidity 0.8.25;
 
 import { BaseTest } from "test/Base.t.sol";
-import { FeedParams } from "test/utils/Types.sol";
-import { IERC20 } from "cowprotocol/contracts/interfaces/IERC20.sol";
 import { stdError } from "forge-std/StdError.sol";
 
 contract LatestRoundData_Concrete_Unit_Test is BaseTest {

--- a/test/unit/latest-round-data/fuzz/LatestRoundData.t.sol
+++ b/test/unit/latest-round-data/fuzz/LatestRoundData.t.sol
@@ -2,10 +2,6 @@
 pragma solidity 0.8.25;
 
 import { BaseTest } from "test/Base.t.sol";
-import { FeedParams } from "test/utils/Types.sol";
-import { IERC20 } from "cowprotocol/contracts/interfaces/IERC20.sol";
-import { stdError } from "forge-std/StdError.sol";
-import { stdMath } from "forge-std/StdMath.sol";
 
 contract LatestRoundData_Fuzz_Unit_Test is BaseTest {
     modifier givenWhenDecimalsLtEq18() {

--- a/test/utils/Defaults.sol
+++ b/test/utils/Defaults.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.8.25 < 0.9.0;
 
 import { Constants } from "test/utils/Constants.sol";
-import { Mocks, OrderParams, TokenParams, FeedParams } from "test/utils/Types.sol";
+import { Mocks, FeedParams } from "test/utils/Types.sol";
 
 contract Defaults is Constants {
     uint256 public constant TOKEN0_BALANCE = 1e18;

--- a/test/utils/Types.sol
+++ b/test/utils/Types.sol
@@ -10,20 +10,6 @@ struct Mocks {
     address feed1;
 }
 
-struct TokenParams {
-    address addr;
-    uint256 balance;
-    uint256 normWeight;
-    uint256 denormWeight;
-}
-
-struct OrderParams {
-    address pool;
-    address factory;
-    TokenParams token0;
-    TokenParams token1;
-}
-
 struct FeedParams {
     address addr;
     uint8 decimals;

--- a/test/utils/Utils.sol
+++ b/test/utils/Utils.sol
@@ -2,7 +2,6 @@
 pragma solidity >=0.8.25 < 0.9.0;
 
 import { Test } from "forge-std/Test.sol";
-import { OrderParams } from "test/utils/Types.sol";
 import { IERC20 } from "cowprotocol/contracts/interfaces/IERC20.sol";
 
 contract Utils is Test {


### PR DESCRIPTION
Changes:
- cleanup unused imports
- other linting issues, such as unspecified visibility and unused variables