### PR TITLE
Change eth and base RPCs

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -23,9 +23,9 @@ tab_width = 4
 wrap_comments = true
 
 [rpc_endpoints]
-mainnet = "https://rpc.ankr.com/eth"
+mainnet = "https://eth.merkle.io"
 sepolia = "https://rpc2.sepolia.org"
 gnosis = "https://rpc.ankr.com/gnosis"
 arbitrum = "https://rpc.ankr.com/arbitrum"
-base = "https://rpc.ankr.com/base"
+base = "https://base.merkle.io"
 localhost = "http://localhost:8545"


### PR DESCRIPTION
There was a flaky fork test that we suspect came from multiple simultaneous rpc requests to the default ankr node. Changing eth and base rpcs to the amazing https://merkle.io/ free-tier!

